### PR TITLE
Fix handling of 'error' entry in dict

### DIFF
--- a/examples/telegraf.conf.d/postgres.conf
+++ b/examples/telegraf.conf.d/postgres.conf
@@ -18,7 +18,7 @@ def apply(metric):
   date = time.parse_time(d['timestamp'], location="UTC").unix_nano
   metrics = []
 
-  if 'error' in d['servers'][server]['postgres'].keys():
+  if 'error' in d['servers'][server]['postgres'].keys() and len(d['servers'][server]['postgres']['error']) > 0:
      return
 
   for k, v in d['servers'][server]['postgres']['connections'].items():

--- a/examples/telegraf.conf.d/puppetdb.conf
+++ b/examples/telegraf.conf.d/puppetdb.conf
@@ -21,7 +21,7 @@ def apply(metric):
   skip_keys = ['error', 'error_count', 'api-query-start', 'api-query-duration', 'puppetdb-status', 'status-service', 'jetty-queuedthreadpool', 'ha_last-sync-succeeded']
   skip_fields = ['RateUnit', 'DurationUnit', 'state']
 
-  if 'error' in d['servers'][server]['puppetdb'].keys():
+  if 'error' in d['servers'][server]['puppetdb'].keys() and len(d['servers'][server]['puppetdb']['error']) > 0:
      return
 
   for k,v in d['servers'][server]['puppetdb'].items():


### PR DESCRIPTION
Prior to this commit, the error checking was too aggressive and resulted
in emitting no metrics from PDB json files.  This is because the 'error'
object is always in the result and we need to check the length of its
values.