### PR TITLE
(SUP-3209) Grant pg_monitor role to telegraf

### DIFF
--- a/manifests/profile/postgres_access.pp
+++ b/manifests/profile/postgres_access.pp
@@ -18,6 +18,13 @@ class puppet_operational_dashboards::profile::postgres_access (
     require    => Class['Pe_postgresql::Server'],
   }
 
+  pe_postgresql::server::database_grant { 'operational_dashboards_telegraf':
+    privilege => 'CONNECT',
+    db        => 'pe-puppetdb',
+    role      => 'telegraf',
+    require   => Pe_postgresql_psql['CREATE ROLE telegraf LOGIN'],
+  }
+
   pe_postgresql_psql { 'telegraf_pg_monitor_grant':
     db         => 'pe-puppetdb',
     port       => '5432',

--- a/manifests/profile/postgres_access.pp
+++ b/manifests/profile/postgres_access.pp
@@ -8,16 +8,15 @@ class puppet_operational_dashboards::profile::postgres_access (
 ) {
   $ident_file = "/opt/puppetlabs/server/data/postgresql/${facts['pe_postgresql_info']['installed_server_version']}/data/pg_ident.conf"
 
-  pe_postgresql_psql {'CREATE ROLE telegraf':
+  pe_postgresql_psql { 'CREATE ROLE telegraf':
     db         => 'pe-puppetdb',
     port       => '5432',
     psql_user  => 'pe-postgres',
     psql_group => 'pe-postgres',
     unless     => "SELECT rolname FROM pg_roles WHERE rolname='telegraf'",
-    psql_path  => "/opt/puppetlabs/server/bin/psql",
+    psql_path  => '/opt/puppetlabs/server/bin/psql',
     require    => Class['Pe_postgresql::Server'],
   }
-
 
   pe_postgresql_psql { 'telegraf_pg_monitor_grant':
     db         => 'pe-puppetdb',
@@ -26,10 +25,9 @@ class puppet_operational_dashboards::profile::postgres_access (
     psql_group => 'pe-postgres',
     command    => 'GRANT pg_monitor TO telegraf',
     unless     => "select 1 from pg_roles where pg_has_role( 'telegraf', 'pg_monitor', 'member')",
-    psql_path  => "/opt/puppetlabs/server/bin/psql",
+    psql_path  => '/opt/puppetlabs/server/bin/psql',
     require    => Pe_postgresql_psql['CREATE ROLE telegraf'],
   }
-
 
   $telegraf_hosts.each |$host| {
     puppet_enterprise::pg::cert_allowlist_entry { "telegraf_${host}":

--- a/manifests/profile/postgres_access.pp
+++ b/manifests/profile/postgres_access.pp
@@ -8,6 +8,29 @@ class puppet_operational_dashboards::profile::postgres_access (
 ) {
   $ident_file = "/opt/puppetlabs/server/data/postgresql/${facts['pe_postgresql_info']['installed_server_version']}/data/pg_ident.conf"
 
+  pe_postgresql_psql {'CREATE ROLE telegraf':
+    db         => 'pe-puppetdb',
+    port       => '5432',
+    psql_user  => 'pe-postgres',
+    psql_group => 'pe-postgres',
+    unless     => "SELECT rolname FROM pg_roles WHERE rolname='telegraf'",
+    psql_path  => "/opt/puppetlabs/server/bin/psql",
+    require    => Class['Pe_postgresql::Server'],
+  }
+
+
+  pe_postgresql_psql { 'telegraf_pg_monitor_grant':
+    db         => 'pe-puppetdb',
+    port       => '5432',
+    psql_user  => 'pe-postgres',
+    psql_group => 'pe-postgres',
+    command    => 'GRANT pg_monitor TO telegraf',
+    unless     => "select 1 from pg_roles where pg_has_role( 'telegraf', 'pg_monitor', 'member')",
+    psql_path  => "/opt/puppetlabs/server/bin/psql",
+    require    => Pe_postgresql_psql['CREATE ROLE telegraf'],
+  }
+
+
   $telegraf_hosts.each |$host| {
     puppet_enterprise::pg::cert_allowlist_entry { "telegraf_${host}":
       user                          => 'telegraf',

--- a/manifests/profile/postgres_access.pp
+++ b/manifests/profile/postgres_access.pp
@@ -8,7 +8,7 @@ class puppet_operational_dashboards::profile::postgres_access (
 ) {
   $ident_file = "/opt/puppetlabs/server/data/postgresql/${facts['pe_postgresql_info']['installed_server_version']}/data/pg_ident.conf"
 
-  pe_postgresql_psql { 'CREATE ROLE telegraf':
+  pe_postgresql_psql { 'CREATE ROLE telegraf LOGIN':
     db         => 'pe-puppetdb',
     port       => '5432',
     psql_user  => 'pe-postgres',
@@ -26,7 +26,7 @@ class puppet_operational_dashboards::profile::postgres_access (
     command    => 'GRANT pg_monitor TO telegraf',
     unless     => "select 1 from pg_roles where pg_has_role( 'telegraf', 'pg_monitor', 'member')",
     psql_path  => '/opt/puppetlabs/server/bin/psql',
-    require    => Pe_postgresql_psql['CREATE ROLE telegraf'],
+    require    => Pe_postgresql_psql['CREATE ROLE telegraf LOGIN'],
   }
 
   $telegraf_hosts.each |$host| {


### PR DESCRIPTION
Prior to this commit, we did not create a postgres role for telegraf or
grant it any permissions.  This add two pe_postgresql_psql resources to
accomplish this.