### PR TITLE
(SUP-3201) Accept any Sensitive value in template

### DIFF
--- a/files/datasource.epp
+++ b/files/datasource.epp
@@ -2,7 +2,7 @@
   String $name,
   String $url,
   String $database,
-  Sensitive[String] $token,
+  Sensitive $token,
 | -%>
 # This file is managed by Puppet, any changes will be overwritten
 ---


### PR DESCRIPTION
Prior to this commit, $token was declared as a Sensitive[String], but we
may recieve an Undef value if the token was created in the current
catalog application.  This commit accepts any Sensitive value to account
for this.