### PR TITLE
(SUP-3201) Check port availability with systemd

### DIFF
--- a/templates/grafana_wait.epp
+++ b/templates/grafana_wait.epp
@@ -1,0 +1,6 @@
+<%- | Integer $timeout | -%>
+# Adapted from https://unix.stackexchange.com/a/584965/226625
+# Wait for the service to be listening on port 3000
+[Service]
+ExecStartPost=/usr/bin/timeout <%= $timeout %> sh -c 'while ! ss -H -t -l -n sport = :3000 | grep -q "^LISTEN.*:3000"; do sleep 1; done'
+


### PR DESCRIPTION
Prior to this commit, we used an exec resource to check if the grafana
service were ready to receive connections.  However, this didn't account
for initial provisioning, and it's a bit of a hack.  This commit uses an
ExecStartPost directive instead, which is better because it allows us to
use metaparameters like 'require' directly on the service.