### PR TITLE
(SUP-3228) Fix Ubuntu compatibility issue

### DIFF
--- a/manifests/telegraf/agent.pp
+++ b/manifests/telegraf/agent.pp
@@ -69,7 +69,7 @@ class puppet_operational_dashboards::telegraf::agent (
   String  $ssl_key_file ="/etc/puppetlabs/puppet/ssl/private_keys/${trusted['certname']}.pem",
   String  $ssl_ca_file ='/etc/puppetlabs/puppet/ssl/certs/ca.pem',
 
-  String $version = '1.21.2',
+  String $version = '1.22.1-1',
   Enum['all', 'local', 'none'] $collection_method = 'all',
   String $collection_interval = '10m',
 
@@ -162,6 +162,7 @@ class puppet_operational_dashboards::telegraf::agent (
     owner  => 'telegraf',
     group  => 'telegraf',
     mode   => '0700',
+    require => Class['telegraf'],
   }
 
   if $token {


### PR DESCRIPTION
encompassing #34 this commit Bumps the telegraf version to the minimum version provided by Ubuntu 20.04

This also adds a missing require to the following file resource:

`file { '/etc/systemd/system/telegraf.service.d':`

This now correctly requires the telegraf class which resolves a resource ordering issue associated with ubuntu