### PR TITLE
(SUP-3061) Install class for ent infrastructure agents

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,2 +1,1 @@
 --relative
---no-lookup_in_parameter-check

--- a/.sync.yml
+++ b/.sync.yml
@@ -24,7 +24,7 @@ appveyor.yml:
   unmanaged: true
 .github/workflows/spec.yml:
   checks: 'syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop'
-  unmanaged: false
+  unmanaged: true
 .github/workflows/release.yml:
   unmanaged: true
 .travis.yml:

--- a/README.md
+++ b/README.md
@@ -2,11 +2,19 @@
 
 ## Table of Contents
 
-1. [Description](#description)
-1. [Setup - The basics of getting started with puppet_operational_dashboards](#setup)
-    * [Beginning with puppet_operational_dashboards](#beginning-with-puppet_operational_dashboards)
-1. [Usage - Configuration options and additional functionality](#usage)
-    * [Determining where Telegraf runs](#determining-where-telegraf-runs)
+- [puppet_operational_dashboards](#puppet_operational_dashboards)
+  - [Table of Contents](#table-of-contents)
+  - [Description](#description)
+  - [Setup](#setup)
+    - [Prerequisites](#prerequisites)
+    - [Beginning with puppet_operational_dashboards](#beginning-with-puppet_operational_dashboards)
+      - [Installing on Puppet Enterprise](#installing-on-puppet-enterprise)
+      - [Installing on Puppet Open Source](#installing-on-puppet-open-source)
+      - [What puppet_operational_dashboards affects](#what-puppet_operational_dashboards-affects)
+  - [Usage](#usage)
+    - [Evaluation order](#evaluation-order)
+    - [Determining where Telegraf runs](#determining-where-telegraf-runs)
+    - [Importing archive metrics](#importing-archive-metrics)
 
 ## Description
 
@@ -17,19 +25,45 @@ This module is a replacement for the [puppet_metrics_dashboard module](https://f
 
 ### Prerequisites
 
-The toml-rb gem needs to be installed in the Puppetserver gem space, which can be done with the [influxdb::profile::toml](https://github.com/puppetlabs/influxdb/blob/main/manifests/profile/toml.pp) class in the InfluxDB module.
-
-To collect PostgreSQL metrics, classify your PostgreSQL nodes with the [puppet_operational_dashboards::profile::postgres_access](https://github.com/puppetlabs/puppet_operational_dashboards/blob/main/manifests/profile/postgres_access.pp) class.  FOSS users will need to manually configure the PostgreSQL authentication settings.
-
 ### Beginning with puppet_operational_dashboards
 
-The easiest way to get started using this module is by including the `puppet_operational_dashboards` class to install and configure Telegraf, InfluxDB, and Grafana.  Note that you also need to install the toml-rb gem according to the [prerequisites](#setup-prerequisites).
+#### Installing on Puppet Enterprise
+
+To Install on Puppet Enterprise:
+
+1. Classify `puppet_operational_dashboards::enterprise_infrastructure` to a node group that encompasses all Puppet Infrastructure agents. The default node group `PE Infrastructure Agent` is appropriate.
+
+```
+include puppet_operational_dashboards::enterprise_infrastructure
+```
+
+This will install the toml-rb gem on compiling nodes, and grant the appropriate access to the databases, for the dashboard node on all database nodes.
+
+2. Classify `puppet_operational_dashboards` to the Puppet agent node to be designated as the Operational Dashboard node.
+
+```
+include puppet_operational_dashboards
+```
+This will install and configure Telegraf, InfluxDB, and Grafana.
+
+
+Please note database access will not be granted until the Puppet agent run on the postgres nodes AFTER the application of `puppet_operational_dashboards` on the designated dashboard node.
+
+
+#### Installing on Puppet Open Source
+
+The toml-rb gem needs to be installed in the Puppetserver gem space, which can be done with the [influxdb::profile::toml](https://github.com/puppetlabs/influxdb/blob/main/manifests/profile/toml.pp) class in the InfluxDB module.
+
+To collect PostgreSQL metrics, FOSS users will need to manually configure the PostgreSQL authentication settings.
+
+The easiest way to get started using this module is by including the `puppet_operational_dashboards` class to install and configure Telegraf, InfluxDB, and Grafana.  Note that you also need to install the toml-rb gem according to the.
 
 ```
 include puppet_operational_dashboards
 ```
 
-Doing so will:
+#### What puppet_operational_dashboards affects
+Installing the module will:
 
 * Install and configure InfluxDB using the [puppetlabs/influxdb module](https://forge.puppet.com/modules/puppetlabs/influxdb#what-influxdb-affects)
 * Install and configure Telegraf to collect metrics from your PE infrastructure.  FOSS users can specify a list of infrastructure nodes via the `puppet_operational_dashboards::telegraf::agent` parameters.

--- a/functions/hosts_with_profile.pp
+++ b/functions/hosts_with_profile.pp
@@ -8,7 +8,6 @@
 #
 # @return [Array[String]]
 #   An array of certnames from the query
-
 function puppet_operational_dashboards::hosts_with_profile(
   String $profile,
 ) >> Array[String] {

--- a/manifests/enterprise_infrastructure.pp
+++ b/manifests/enterprise_infrastructure.pp
@@ -1,0 +1,20 @@
+# @summary Installs dependancies for Operational dashboards on PE infrastructure components
+#
+# When applied to an appropriate node group this class applies the toml gem and database access
+# On appropriate infrastructure nodes in PE
+#
+# @example
+#   include puppet_operational_dashboards::enterprise_infrastructure
+# @param profiles
+#   Array of PE profiles on the node with this class applied. 
+class puppet_operational_dashboards::enterprise_infrastructure (
+  Array[String] $profiles = puppet_operational_dashboards::pe_profiles_on_host(),
+) {
+  if   ('Puppet_enterprise::Profile::Master' in $profiles) {
+    include influxdb::profile::toml
+  }
+
+  if  ('Puppet_enterprise::Profile::Database' in $profiles) {
+    include puppet_operational_dashboards::profile::postgres_access
+  }
+}

--- a/manifests/telegraf/agent.pp
+++ b/manifests/telegraf/agent.pp
@@ -69,7 +69,7 @@ class puppet_operational_dashboards::telegraf::agent (
   String  $ssl_key_file ="/etc/puppetlabs/puppet/ssl/private_keys/${trusted['certname']}.pem",
   String  $ssl_ca_file ='/etc/puppetlabs/puppet/ssl/certs/ca.pem',
 
-  String $version = '1.22.1-1',
+  String $version = '1.22.2-1',
   Enum['all', 'local', 'none'] $collection_method = 'all',
   String $collection_interval = '10m',
 

--- a/metadata.json
+++ b/metadata.json
@@ -75,7 +75,7 @@
       "version_requirement": ">= 4.7.0 < 8.0.0"
     }
   ],
-  "pdk-version": "2.3.0",
+  "pdk-version": "2.4.0",
   "template-url": "https://github.com/puppetlabs/pdk-templates#main",
-  "template-ref": "heads/main-0-gf3911d3"
+  "template-ref": "tags/2.5.0-0-g806810b"
 }

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -1,8 +1,22 @@
 
 require 'spec_helper_acceptance'
 
-describe 'puppet_operational_dashboards class' do
-  context 'init with default parameters' do
+describe 'install dashboards and set up dependancies' do
+  context 'apply enterprise_infrastructure  with default parameters' do
+    it 'installs tomlrb and dbaccess' do
+      inf = <<-MANIFEST
+           service { 'pe-puppetserver': }
+      include puppet_operational_dashboards::enterprise_infrastructure
+     package { 'toml-rb puppet_gem':
+       name     => 'toml-rb',
+       ensure   => installed,
+       provider => 'puppet_gem',
+     }
+           MANIFEST
+      idempotent_apply(inf)
+    end
+  end
+  context 'init puppet_operational_dashboards with default parameters' do
     it 'installs grafana and influxdb' do
       pp = <<-MANIFEST
         include puppet_operational_dashboards

--- a/spec/classes/enterprise_infrastructure_spec.rb
+++ b/spec/classes/enterprise_infrastructure_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'puppet_operational_dashboards::enterprise_infrastructure' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let(:pre_condition) do
+        <<-PRE_COND
+        class influxdb::profile::toml {}
+        PRE_COND
+      end
+
+      it { is_expected.to compile }
+    end
+  end
+end

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -6,11 +6,5 @@ ipaddress: "172.16.254.254"
 ipaddress6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
 is_pe: false
 macaddress: "AA:AA:AA:AA:AA:AA"
-pe_build: 2021.4.0
-self_service:
-  S0001: true
-  S0002: true
-  S0003: true
-  S0004: true
-  S0005: true
+pe_build: 2021.5.0
 

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -10,15 +10,5 @@ RSpec.configure do |c|
   c.before :suite do
     # Download the plugins and install required toml gem
     PuppetLitmus::PuppetHelpers.run_shell('/opt/puppetlabs/bin/puppet plugin download')
-    pp = <<-PUPPETCODE
-     service { 'pe-puppetserver': }
-     include  influxdb::profile::toml
-     package { 'toml-rb puppet_gem':
-       name     => 'toml-rb',
-       ensure   => installed,
-       provider => 'puppet_gem',
-     }
-     PUPPETCODE
-    apply_manifest(pp)
   end
 end


### PR DESCRIPTION
Prior to this commit, it was necessary to manually apply the toml-rb gem to compiling nodes, and apply the postgres_access class to database nodes.

This commit adds puppet_operational_dashboards::enterprise_infrastructure which when applied to the puppet infrastructure node group, automatically selects and applies appropriate prerequisites.

Marked as "backward-incompatible" as this is likely a change that warrants a 1.0 release when rolled up with all other recent changes