### PR TITLE
(SUP-3235) Use latest telegraf package on Ubuntu

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,1 +1,2 @@
 --relative
+--no-lookup_in_parameter-check

--- a/.sync.yml
+++ b/.sync.yml
@@ -34,6 +34,8 @@ spec/spec_helper.rb:
   coverage_report: true
 Rakefile:
   changelog_user: "puppetlabs"
+  extra_disabled_lint_checks:
+    - 'lookup_in_parameter'
 spec/default_facts.yml:
   extra_facts:
     pe_build: '2021.5.0'

--- a/README.md
+++ b/README.md
@@ -135,3 +135,7 @@ Or one service at a time, e.g. for Puppet server
 ```
 telegraf --once --debug --config ~/telegraf.conf --config ~/telegraf.conf.d//puppetserver.conf
 ```
+
+### Limitations
+
+Currently, only the latest Telegraf package is provided by the Ubuntu repository.  Therefore, the only allowed value for `puppet_operational_dashboards::telegraf::agent::version` is `latest`.  Setting this parameter to a different value on Ubuntu will produce a warning.

--- a/Rakefile
+++ b/Rakefile
@@ -42,6 +42,7 @@ def changelog_future_release
 end
 
 PuppetLint.configuration.send('disable_relative')
+PuppetLint.configuration.send('disable_lookup_in_parameter')
 
 
 if Bundler.rubygems.find_name('github_changelog_generator').any?

--- a/manifests/telegraf/agent.pp
+++ b/manifests/telegraf/agent.pp
@@ -104,9 +104,16 @@ class puppet_operational_dashboards::telegraf::agent (
     notify => Service['telegraf'],
   }
 
+  # Only the latest telegraf package seems to be available for Ubuntu
+  $version_ensure = $facts['os']['name'] ? {
+    'Ubuntu' => 'latest',
+    default  => $version,
+  }
+
   class { 'telegraf':
-    ensure           => $version,
-    archive_location => 'https://dl.influxdata.com/telegraf/releases/telegraf-1.21.2_linux_amd64.tar.gz',
+    ensure           => $version_ensure,
+    # Use the $version parameter to determine the archive link, stripping the '-1' suffix.
+    archive_location => "https://dl.influxdata.com/telegraf/releases/telegraf-${version.split('-')[0]}_linux_amd64.tar.gz",
     interval         => $collection_interval,
     hostname         => '',
     manage_service   => false,

--- a/manifests/telegraf/agent.pp
+++ b/manifests/telegraf/agent.pp
@@ -68,8 +68,11 @@ class puppet_operational_dashboards::telegraf::agent (
   String  $ssl_cert_file = "/etc/puppetlabs/puppet/ssl/certs/${trusted['certname']}.pem",
   String  $ssl_key_file ="/etc/puppetlabs/puppet/ssl/private_keys/${trusted['certname']}.pem",
   String  $ssl_ca_file ='/etc/puppetlabs/puppet/ssl/certs/ca.pem',
-
-  String $version = '1.22.2-1',
+  # Only the latest telegraf package seems to be available for Ubuntu
+  String $version = $facts['os']['name'] ? {
+    'Ubuntu' => 'latest',
+    default  => '1.22.2-1',
+  },
   Enum['all', 'local', 'none'] $collection_method = 'all',
   String $collection_interval = '10m',
 
@@ -104,7 +107,13 @@ class puppet_operational_dashboards::telegraf::agent (
     notify => Service['telegraf'],
   }
 
-  # Only the latest telegraf package seems to be available for Ubuntu
+  if $facts['os']['name'] == 'Ubuntu' and $version != 'latest' {
+    notify { 'telegraf_ubuntu_warn':
+      message  => "Using 'latest' for Telegraf package on Ubuntu",
+      loglevel => 'warning',
+    }
+  }
+
   $version_ensure = $facts['os']['name'] ? {
     'Ubuntu' => 'latest',
     default  => $version,


### PR DESCRIPTION
Prior to this commit, Ubuntu provisioning would fail if the latest
telegraf package were newer than the $version parameter.  This looks to
be because only the latest package is available in the Ubuntu repo.
This commit changes the ensure property to be 'latest' on Ubuntu, and
changes the archive url to use the $version parameter.