### PR TITLE
Fix queue_depth metric in starlark processor

### DIFF
--- a/examples/telegraf.conf.d/puppetdb.conf
+++ b/examples/telegraf.conf.d/puppetdb.conf
@@ -40,6 +40,13 @@ def apply(metric):
 
       metrics.append(m)
 
+  queue_depth = d['servers'][server]['puppetdb']['puppetdb-status']['status']['queue_depth']
+  m = Metric("puppetdb")
+  m.time = date
+  m.tags['url'] = server
+  m.fields['queue_depth'] = queue_depth
+  metrics.append(m)
+
   if 'jetty-queuedthreadpool' in d['servers'][server]['puppetdb'].keys():
      for k,v in d['servers'][server]['puppetdb']['jetty-queuedthreadpool'].items():
        if k not in skip_keys:


### PR DESCRIPTION
Prior to this commit, this metric was not being emitted from archive
metrics because I had confused jetty's queueSize metric with PDB's
queue_depth.  This commit emits the correct metric for the dashboard to
pick up.