### PR TITLE
(SUP-3319) Refresh service when datasource changes

### DIFF
--- a/manifests/profile/dashboards.pp
+++ b/manifests/profile/dashboards.pp
@@ -110,7 +110,8 @@ class puppet_operational_dashboards::profile::dashboards (
           database => $influxdb_bucket,
           url      => $influxdb_uri,
       }),
-      before  => Service['grafana-server'],
+      require => Class['grafana::install'],
+      notify  => Service['grafana-server'],
     }
   }
   else {
@@ -127,8 +128,8 @@ class puppet_operational_dashboards::profile::dashboards (
       owner   => 'grafana',
       content => Deferred('inline_epp',
       [file('puppet_operational_dashboards/datasource.epp'), $token_vars]),
-      require => Class['Grafana::Install'],
-      before  => Service['grafana-server'],
+      require => Class['grafana::install'],
+      notify  => Service['grafana-server'],
     }
   }
 


### PR DESCRIPTION
Prior to this commit, the provisioning datasource file had a 'before'
metaparam on the Grafana service, which caused the service not to
refresh when the file changes.  This commit fixes this by changing the
'before' to a 'notify'.  The 'require' on the Grafana install class
still ensures proper ordering.