### PR TITLE
(SUP-3348) Telegraf ssl bugfixes

### DIFF
--- a/manifests/telegraf/agent.pp
+++ b/manifests/telegraf/agent.pp
@@ -184,10 +184,11 @@ class puppet_operational_dashboards::telegraf::agent (
   }
 
   file { '/etc/systemd/system/telegraf.service.d':
-    ensure => directory,
-    owner  => 'telegraf',
-    group  => 'telegraf',
-    mode   => '0700',
+    ensure  => directory,
+    owner   => 'telegraf',
+    group   => 'telegraf',
+    mode    => '0700',
+    require => Class['telegraf::install'],
   }
 
   if $token {

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -7,4 +7,8 @@ ipaddress6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
 is_pe: false
 macaddress: "AA:AA:AA:AA:AA:AA"
 pe_build: 2021.5.0
+os:
+  family: RedHat
+identity:
+  user: root
 


### PR DESCRIPTION
This commit fixes a couple of issues related to Telegraf ssl
configuration.

* The service may have been started before the files were copied to
  /etc/telegraf
* Changing this configuration did not refresh the Telegraf service
* The configuration didn't take the $use_ssl parameter into account