### PR TITLE
(SUP-3358) Fix $use_ssl logic across all manifests

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,16 +58,11 @@ class puppet_operational_dashboards (
     fail("Installation on ${facts['os']['family']} is not supported")
   }
 
-  $protocol = $use_ssl ? {
-    true  => 'https',
-    false => 'http',
-  }
-  $influxdb_uri = "${protocol}://${influxdb_host}:${influxdb_port}"
-
   if $manage_influxdb {
     class { 'influxdb':
       host        => $influxdb_host,
       port        => $influxdb_port,
+      use_ssl     => $use_ssl,
       initial_org => $initial_org,
       token_file  => $influxdb_token_file,
     }
@@ -88,7 +83,6 @@ class puppet_operational_dashboards (
 
     Influxdb_auth {
       require => Class['influxdb'],
-      token_file  => $influxdb_token_file,
     }
   }
 

--- a/manifests/profile/dashboards.pp
+++ b/manifests/profile/dashboards.pp
@@ -58,7 +58,7 @@ class puppet_operational_dashboards::profile::dashboards (
     default           => 'package',
   },
   String $provisioning_datasource_file = '/etc/grafana/provisioning/datasources/influxdb.yaml',
-  Boolean $use_ssl = true,
+  Boolean $use_ssl = $puppet_operational_dashboards::use_ssl,
   Boolean $manage_grafana_repo = true,
   String $influxdb_host = $puppet_operational_dashboards::influxdb_host,
   Integer $influxdb_port = $puppet_operational_dashboards::influxdb_port,


### PR DESCRIPTION
This commit fixes a few issues with this parameter, namely

* Not passing it to the 'influxdb' class
* Defaulting to 'https' in some classes and defined types