### PR TITLE
(SUP-3431) Add index and toast stats to postgres

### DIFF
--- a/examples/telegraf.conf.d/postgres.conf
+++ b/examples/telegraf.conf.d/postgres.conf
@@ -60,6 +60,9 @@ def apply(metric):
     for k,v in subdict[db]['database_stats'].items():
       if v == None:
         continue
+
+      field = 'total' if k == 'size_bytes' else k
+      m.fields[field] = v
       m.fields[k] = v
     metrics.append(m)
 
@@ -67,15 +70,50 @@ def apply(metric):
        for table in subdict[db]['table_stats'].keys():
          m = Metric("postgresql")
          m.tags['db'] = db
-         m.tags['table'] = table
+         m.tags['table_name'] = table
          m.tags['server'] = server
          m.time = date
          for k,v in subdict[db]['table_stats'][table].items():
            if v == None:
              continue
-           m.fields[k] = v
+
+           field = 'table' if k == 'size_bytes' else k
+           m.fields[field] = v
          metrics.append(m)
 
+    if 'index_stats' in subdict[db].keys():
+       for table in subdict[db]['index_stats'].keys():
+         table_name = table.split('.')[-1]
+
+         m = Metric("postgresql")
+         m.tags['db'] = db
+         m.tags['table_name'] = table_name
+         m.tags['server'] = server
+         m.time = date
+         for k,v in subdict[db]['index_stats'][table].items():
+           if v == None:
+             continue
+
+           field = 'index' if k == 'size_bytes' else k
+           m.fields[field] = v
+         metrics.append(m)
+
+    if 'toast_stats' in subdict[db].keys():
+       for table in subdict[db]['toast_stats'].keys():
+         table_name = table.split('.')[-1]
+
+         m = Metric("postgresql")
+         m.tags['db'] = db
+         m.tags['table_name'] = table.split('.')[-1]
+         m.tags['server'] = server
+         m.time = date
+         for k,v in subdict[db]['toast_stats'][table].items():
+           if v == None:
+             continue
+
+           field = 'toast' if k == 'size_bytes' else k
+           m.fields[field] = v
+         metrics.append(m)
   return metrics
 '''
 [processors.starlark.tagpass]


### PR DESCRIPTION
This commit adds index and toast metrics to be emitted by the postgres
starlark script.  It also fixes a small discrepency between the fields
emitted by the script and those expected by the dashboard