### PR TITLE
(SUP-3565) Support Telegraf archive install on EL

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
   - [Description](#description)
   - [Setup](#setup)
     - [Prerequisites](#prerequisites)
+    - [Note on air-gapped environments](#note-on-air-gapped-environments)
     - [Beginning with puppet_operational_dashboards](#beginning-with-puppet_operational_dashboards)
       - [Installing on Puppet Enterprise](#installing-on-puppet-enterprise)
       - [Installing on Puppet Open Source](#installing-on-puppet-open-source)
@@ -39,6 +40,31 @@ This module is a replacement for the [puppet_metrics_dashboard module](https://f
 ## Setup
 
 ### Prerequisites
+
+### Note on air-gapped environments
+
+If you are applying either the `puppet_operational_dashboards` or `puppet_operational_dashboards::telegraf::agent` classes to a node that cannot access the internet, it is possible to install packages from an archive source located within the air gap.
+
+For InfluxDB, set:
+
+* [influxdb::manage_repo](https://forge.puppet.com/modules/puppetlabs/influxdb/reference#manage_repo) to `false`
+* [influxdb::archive_source](https://forge.puppet.com/modules/puppetlabs/influxdb/reference#archive_source) to an internal URL containing the archive file for InfluxDB
+
+For Grafana, set:
+
+* [grafana::install_method](https://forge.puppet.com/modules/puppet/grafana/reference#install_method) to either `archive` or `package` depending on your preferred method.
+
+Then, set either of the following depending on the installation method
+
+* [grafana::package_source](https://forge.puppet.com/modules/puppet/grafana/reference#package_source)
+* [grafana::archive_source](https://forge.puppet.com/modules/puppetlabs/influxdb/reference#archive_source)
+
+#TODO: document these in the PR that generates the changelog and reference
+For Telegraf, set:
+
+* `puppet_operational_dashboards::telegraf::agent::manage_repo` to `false`
+* `puppet_operational_dashboards::telegraf::agent::manage_archive` to `true`
+* `puppet_operational_dashboards::telegraf::agent::archive_location` to an internal URL containing the archive file for Telegraf
 
 ### Beginning with puppet_operational_dashboards
 

--- a/manifests/telegraf/agent.pp
+++ b/manifests/telegraf/agent.pp
@@ -75,8 +75,9 @@ class puppet_operational_dashboards::telegraf::agent (
   String $influxdb_org = $puppet_operational_dashboards::initial_org,
   Boolean $use_ssl = $puppet_operational_dashboards::use_ssl,
   Boolean $manage_ssl = true,
+  #TODO: move platform specific parameters to module data
   Boolean $manage_repo = $facts['os']['family'] ? {
-    'RedHat' => true,
+    /(RedHat|Debian)/ => true,
     default  => false,
   },
   Boolean $manage_archive = !$manage_repo,

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppet-telegraf",
-      "version_requirement": ">= 4.1.0 < 5.0.0"
+      "version_requirement": ">= 4.3.0 < 5.0.0"
     },
     {
       "name": "puppetlabs-apt",
@@ -26,7 +26,7 @@
     },
     {
       "name": "puppetlabs-influxdb",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
+      "version_requirement": ">= 1.3.1 < 2.0.0"
     },
     {
       "name": "puppetlabs-stdlib",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'pry'
 
 describe 'puppet_operational_dashboards' do
   let(:facts) { { os: { family: 'RedHat' } } }


### PR DESCRIPTION
This commit adds support for installing Telegraf from an archive source
on Enterprise Linux variants.