### PR TITLE
(SUP-3646) Grafana Bump for security vulnerability

### DIFF
--- a/manifests/profile/dashboards.pp
+++ b/manifests/profile/dashboards.pp
@@ -53,7 +53,7 @@ class puppet_operational_dashboards::profile::dashboards (
   Integer $grafana_timeout = 10,
   #TODO: document using task to change
   Sensitive[String] $grafana_password = Sensitive('admin'),
-  String $grafana_version = '8.2.2',
+  String $grafana_version = '8.5.11',
   String $grafana_datasource = 'influxdb_puppet',
   String $grafana_install = $facts['os']['family'] ? {
     /(RedHat|Debian)/ => 'repo',

--- a/manifests/profile/dashboards.pp
+++ b/manifests/profile/dashboards.pp
@@ -53,7 +53,7 @@ class puppet_operational_dashboards::profile::dashboards (
   Integer $grafana_timeout = 10,
   #TODO: document using task to change
   Sensitive[String] $grafana_password = Sensitive('admin'),
-  String $grafana_version = '8.5.11',
+  String $grafana_version = '8.2.7',
   String $grafana_datasource = 'influxdb_puppet',
   String $grafana_install = $facts['os']['family'] ? {
     /(RedHat|Debian)/ => 'repo',

--- a/spec/classes/dashboards_spec.rb
+++ b/spec/classes/dashboards_spec.rb
@@ -24,7 +24,7 @@ describe 'puppet_operational_dashboards::profile::dashboards' do
   context 'when using default parameters' do
     it {
       is_expected.to contain_class('grafana').with(
-        version: '8.5.11',
+        version: '8.2.7',
         manage_package_repo: true,
       )
 

--- a/spec/classes/dashboards_spec.rb
+++ b/spec/classes/dashboards_spec.rb
@@ -24,7 +24,7 @@ describe 'puppet_operational_dashboards::profile::dashboards' do
   context 'when using default parameters' do
     it {
       is_expected.to contain_class('grafana').with(
-        version: '8.2.2',
+        version: '8.5.11',
         manage_package_repo: true,
       )
 


### PR DESCRIPTION
went to latest in 8.x stream as 9.x stream may require dev effort

https://grafana.com/blog/2021/12/07/grafana-8.3.1-8.2.7-8.1.8-and-8.0.7-released-with-high-severity-security-fix/