### PR TITLE
(SUP-3675) Remove -H flag from ss command

### DIFF
--- a/spec/classes/dashboards_spec.rb
+++ b/spec/classes/dashboards_spec.rb
@@ -40,7 +40,9 @@ describe 'puppet_operational_dashboards::profile::dashboards' do
       end
 
       is_expected.to contain_file('grafana-conf-d')
-      is_expected.to contain_file('wait-for-grafana').with_content(%r{ExecStartPost=/usr/bin/timeout 10 sh -c 'while ! ss -H -t -l -n sport = :3000 | grep -q "^LISTEN.*:3000"; do sleep 1; done'})
+      is_expected.to contain_file('wait-for-grafana').with_content(
+        %r{ExecStartPost=/usr/bin/timeout 10 sh -c 'while ! ss -t -l -n sport = :3000 | sed 1d | grep -q "^LISTEN.*:3000"; do sleep 1; done'},
+      )
       is_expected.to contain_file('wait-for-grafana').that_subscribes_to('Exec[puppet_grafana_daemon_reload]')
 
       is_expected.to contain_exec('puppet_grafana_daemon_reload').that_notifies('Service[grafana-server]')

--- a/templates/grafana_wait.epp
+++ b/templates/grafana_wait.epp
@@ -2,5 +2,5 @@
 # Adapted from https://unix.stackexchange.com/a/584965/226625
 # Wait for the service to be listening on port 3000
 [Service]
-ExecStartPost=/usr/bin/timeout <%= $timeout %> sh -c 'while ! ss -H -t -l -n sport = :3000 | grep -q "^LISTEN.*:3000"; do sleep 1; done'
+ExecStartPost=/usr/bin/timeout <%= $timeout %> sh -c 'while ! ss -t -l -n sport = :3000 | sed 1d | grep -q "^LISTEN.*:3000"; do sleep 1; done'
 


### PR DESCRIPTION
This flag to remove the header may not be available on all versions of ss, so use sed to delete it instead.