### PR TITLE
Accept a support script tarball for archive metrics ingest

### DIFF
--- a/files/plan_files/import_archives.sh
+++ b/files/plan_files/import_archives.sh
@@ -1,16 +1,46 @@
 #!/bin/bash
 
-conf_dir="$1"
-metrics_dir="$2"
-cleanup="$3"
+while getopts ":t:m:s:c" opt; do
+  case $opt in
+    t)
+      telegraf_dir="$OPTARG"
+      ;;
+    m)
+      metrics_dir="$OPTARG"
+      ;;
+    s)
+      support_script="$OPTARG"
+      ;;
+    c)
+      cleanup='true'
+      ;;
+    *)
+      echo "WARN: invalid option $opt received"
+  esac
+done
 
-cd "$metrics_dir" || exit 1
+if [[ $support_script ]]; then
+  _tmp="$(mktemp -d -p "$telegraf_dir")"
+
+  tar xf "$support_script" -C "$_tmp" --strip-components=1 || {
+    echo "Failed to extract $support_script"
+    exit 1
+  }
+
+  cd "$_tmp" || exit 1
+else
+  cd "$metrics_dir" || exit 1
+fi
+
 find metrics -type f -name "*gz" -execdir tar xf "{}" \;
 
-out="$(telegraf --once --debug --config "${conf_dir}/telegraf.conf" --config-directory "${conf_dir}/telegraf.conf.d")"
+out="$(telegraf --once --debug --config "${telegraf_dir}/telegraf.conf" --config-directory "${telegraf_dir}/telegraf.conf.d")"
 
-if [[ $cleanup == true ]] && [[ -e ${metrics_dir}/metrics ]]; then
-  rm "${metrics_dir}/metrics" -rf
+if [[ $cleanup == true ]]; then
+  [[ -e ${metrics_dir}/metrics ]] && rm "${metrics_dir}/metrics" -rf
+  [[ -e $_tmp ]] && rm "$_tmp" -rf
+  [[ -e $support_script ]] && rm "$support_script"
 fi
+
 
 echo "$out"


### PR DESCRIPTION
This option ends up being faster than uploading the metrics directory specifically, as Bolt is faster at uploading a single file rather than many small files.