### PR TITLE
(SUP-3735) have dashboards autorefresh

### DIFF
--- a/files/Filesync_performance.json
+++ b/files/Filesync_performance.json
@@ -1364,7 +1364,7 @@
       }
     }
   ],
-  "refresh": false,
+  "refresh": true,
   "schemaVersion": 32,
   "style": "dark",
   "tags": [

--- a/files/Filesync_performance.json
+++ b/files/Filesync_performance.json
@@ -1364,7 +1364,7 @@
       }
     }
   ],
-  "refresh": true,
+  "refresh": "5m",
   "schemaVersion": 32,
   "style": "dark",
   "tags": [

--- a/files/Postgresql_performance.json
+++ b/files/Postgresql_performance.json
@@ -2230,7 +2230,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": false,
+  "refresh": true,
   "schemaVersion": 32,
   "style": "dark",
   "tags": [

--- a/files/Postgresql_performance.json
+++ b/files/Postgresql_performance.json
@@ -2230,7 +2230,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": true,
+  "refresh": "5m",
   "schemaVersion": 32,
   "style": "dark",
   "tags": [

--- a/files/Puppetdb_performance.json
+++ b/files/Puppetdb_performance.json
@@ -2895,7 +2895,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": true,
+  "refresh": "5m",
   "schemaVersion": 32,
   "style": "dark",
   "tags": [

--- a/files/Puppetdb_performance.json
+++ b/files/Puppetdb_performance.json
@@ -2895,7 +2895,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": "",
+  "refresh": true,
   "schemaVersion": 32,
   "style": "dark",
   "tags": [

--- a/files/Puppetserver_performance.json
+++ b/files/Puppetserver_performance.json
@@ -3058,7 +3058,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": true,
+  "refresh": "5m",
   "schemaVersion": 32,
   "style": "dark",
   "tags": [

--- a/files/Puppetserver_performance.json
+++ b/files/Puppetserver_performance.json
@@ -3058,7 +3058,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": false,
+  "refresh": true,
   "schemaVersion": 32,
   "style": "dark",
   "tags": [


### PR DESCRIPTION
Prior to this commit the dashboards where static until refreshed manually in the UI.
The new default behaviour for all dashboards, other than the system data dashboard (because its static data) is to autorefresh, _defaulting to the number 1 option, which in this case is 5(s)_

changed to 5m