### PR TITLE
Update bolt-project.yaml dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@
 .envrc
 /inventory.yaml
 /spec/fixtures/litmus_inventory.yaml
+.modules/
+*_cache*
+*.log
+.rerun.json

--- a/.sync.yml
+++ b/.sync.yml
@@ -10,6 +10,12 @@ common:
 
 ".gitlab-ci.yml":
   delete: true
+.gitignore:
+  paths:
+    - ".modules/"
+    - "*_cache*"
+    - "*.log"
+    - ".rerun.json"
 appveyor.yml:
   delete: true
 .gitpod.Dockerfile:

--- a/Puppetfile
+++ b/Puppetfile
@@ -1,0 +1,13 @@
+# This Puppetfile is managed by Bolt. Do not edit.
+# For more information, see https://pup.pt/bolt-modules
+
+# The following directive installs modules to the managed moduledir.
+moduledir '.modules'
+
+mod 'puppetlabs/inifile', '5.4.0'
+mod 'puppet/telegraf', '4.3.0'
+mod 'puppet/grafana', '11.0.0'
+mod 'puppetlabs/influxdb', '1.3.1'
+mod 'puppet/archive', '6.0.2'
+mod 'puppetlabs/stdlib', '8.5.0'
+mod 'puppetlabs/apt', '8.5.0'

--- a/bolt-project.yaml
+++ b/bolt-project.yaml
@@ -1,8 +1,12 @@
 ---
 name: puppet_operational_dashboards
 modules:
-- name: puppetlabs-stdlib
+- name: puppet-archive
 - name: puppetlabs-influxdb
 - name: puppet-grafana
 - name: puppet-telegraf
-- name: puppetlabs-apt
+- name: puppetlabs-inifile
+plans:
+- puppet_operational_dashboards::*
+tasks:
+- puppet_operational_dashboards::*


### PR DESCRIPTION
Update bolt-project.yaml dependencies.  For example, stdlib and apt aren't required as they're sub-dependencies of other required modules.

Also,
* added some ignores to .sync.yaml
* added a Puppetfile that shows the latest versions.  Why add this?  Because by running ``bolt module install --force`` you can immediately see if any of the dependencies can be uplifted, i.e., telegraf, stdlib, etc.