### PR TITLE
Correct grafana_install method in airgap example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ For InfluxDB, set:
 
 For Grafana, set:
 
-* [grafana::install_method](https://forge.puppet.com/modules/puppet/grafana/reference#install_method) to either `archive` or `package` depending on your preferred method.
+* [puppet_operational_dashboards::profile::dashboards::grafana_install](https://forge.puppet.com/modules/puppetlabs/puppet_operational_dashboards/reference#grafana_install) to either `archive` or `package` depending on your preferred method.
 
 Then, set either of the following depending on the installation method
 


### PR DESCRIPTION
Prior to this commit, we said to use grafana::install_method to change the installation method.  However, we have a parameter puppet_operational_dashboards::profile::dashboards::grafana_install that determines this, so it should be used instead.