### PR TITLE
Fix JRuby lock wait and held times

### DIFF
--- a/files/Filesync_performance.json
+++ b/files/Filesync_performance.json
@@ -172,7 +172,7 @@
             [
               {
                 "params": [
-                  "file-sync-client-service_status_experimental_metrics_average-lock-held-time"
+                  "average-lock-held-time"
                 ],
                 "type": "field"
               },
@@ -222,7 +222,7 @@
             [
               {
                 "params": [
-                  "file-sync-client-service_status_experimental_metrics_average-lock-wait-time"
+                  "average-lock-wait-time"
                 ],
                 "type": "field"
               },


### PR DESCRIPTION
Commit 94a351c3 corrected the file sync client field names to match those stored in InfluxDB.  However, it also changed the JRuby lock and wait times, which is incorrect because those fields don't come from the file sync client metrics.  They are part of the 'jruby-metrics' object, so this commit changes them back to match.