### PR TITLE
Group the total db size by 5m intervals

### DIFF
--- a/files/Postgresql_performance.json
+++ b/files/Postgresql_performance.json
@@ -253,7 +253,7 @@
           "groupBy": [
             {
               "params": [
-                "$__interval"
+                "5m"
               ],
               "type": "time"
             },


### PR DESCRIPTION
Prior to this commit, we used the magic $__interval for the total db sizes in the postgres dashboard.  But, since this uses a sum() of multiple "total" columns, the data was skewed when changing the interval in the graph.  This commit uses 5m since that is the default interval for the metrics collector, and the panel should work for any interval
5m or longer.