### PR TITLE
(SUP-4087) Add Orchestrator metrics

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -41,6 +41,8 @@ spec/default_facts.yml:
     pe_build: '2021.5.0'
     identity:
       user: 'root'
+    settings:
+      module_groups: 'base+pe_only'
 
     
 Gemfile:

--- a/files/Filesync_performance.json
+++ b/files/Filesync_performance.json
@@ -124,10 +124,10 @@
       "pluginVersion": "8.2.2",
       "targets": [
         {
-          "alias": "$tag_url-jruby-puppetserver-lock-held",
+          "alias": "$tag_url-lock_held",
           "datasource": {
             "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
+            "uid": "${datasource}"
           },
           "dsType": "influxdb",
           "groupBy": [
@@ -178,10 +178,10 @@
           ]
         },
         {
-          "alias": "$tag_url-jruby-puppetserver-lock-wait",
+          "alias": "$tag_url-lock_wait",
           "datasource": {
             "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
+            "uid": "${datasource}"
           },
           "dsType": "influxdb",
           "groupBy": [
@@ -232,7 +232,7 @@
           ]
         }
       ],
-      "title": "JRuby Puppet Server Lock Times",
+      "title": "JRuby Lock Times",
       "type": "timeseries"
     },
     {
@@ -315,7 +315,7 @@
           "alias": "$tag_url-$m-clone",
           "datasource": {
             "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
+            "uid": "${datasource}"
           },
           "dsType": "influxdb",
           "groupBy": [
@@ -371,7 +371,7 @@
           "alias": "$tag_url-$m-fetch",
           "datasource": {
             "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
+            "uid": "${datasource}"
           },
           "dsType": "influxdb",
           "groupBy": [
@@ -425,7 +425,7 @@
           "alias": "$tag_url-$m-sync_clean",
           "datasource": {
             "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
+            "uid": "${datasource}"
           },
           "dsType": "influxdb",
           "groupBy": [
@@ -479,7 +479,7 @@
           "alias": "$tag_url-$m-sync",
           "datasource": {
             "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
+            "uid": "${datasource}"
           },
           "dsType": "influxdb",
           "groupBy": [
@@ -533,7 +533,7 @@
           "alias": "$tag_url-$m-sync-callback",
           "datasource": {
             "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
+            "uid": "${datasource}"
           },
           "dsType": "influxdb",
           "groupBy": [
@@ -588,7 +588,7 @@
           "alias": "$tag_url-sync-$m-end_callback",
           "datasource": {
             "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
+            "uid": "${datasource}"
           },
           "dsType": "influxdb",
           "groupBy": [
@@ -643,7 +643,7 @@
           "alias": "$tag_url-$m-sync_prep",
           "datasource": {
             "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
+            "uid": "${datasource}"
           },
           "dsType": "influxdb",
           "groupBy": [
@@ -698,7 +698,7 @@
           "alias": "$tag_url-$m-client-update",
           "datasource": {
             "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
+            "uid": "${datasource}"
           },
           "dsType": "influxdb",
           "groupBy": [
@@ -837,7 +837,7 @@
           "alias": "$tag_url-$m-fetch",
           "datasource": {
             "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
+            "uid": "${datasource}"
           },
           "groupBy": [
             {
@@ -878,10 +878,8 @@
                 "type": "distinct"
               },
               {
-                "params": [
-                  "$__interval"
-                ],
-                "type": "non_negative_derivative"
+                "params": [],
+                "type": "non_negative_difference"
               }
             ]
           ],
@@ -897,7 +895,7 @@
           "alias": "$tag_url-$m-clone",
           "datasource": {
             "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
+            "uid": "${datasource}"
           },
           "groupBy": [
             {
@@ -938,10 +936,8 @@
                 "type": "distinct"
               },
               {
-                "params": [
-                  "$__interval"
-                ],
-                "type": "non_negative_derivative"
+                "params": [],
+                "type": "non_negative_difference"
               }
             ]
           ],
@@ -957,7 +953,7 @@
           "alias": "$tag_url-$m-sync",
           "datasource": {
             "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
+            "uid": "${datasource}"
           },
           "groupBy": [
             {
@@ -998,10 +994,8 @@
                 "type": "distinct"
               },
               {
-                "params": [
-                  "$__interval"
-                ],
-                "type": "non_negative_derivative"
+                "params": [],
+                "type": "non_negative_difference"
               }
             ]
           ],
@@ -1017,7 +1011,7 @@
           "alias": "$tag_url-$m-sync-clean",
           "datasource": {
             "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
+            "uid": "${datasource}"
           },
           "groupBy": [
             {
@@ -1058,10 +1052,8 @@
                 "type": "distinct"
               },
               {
-                "params": [
-                  "$__interval"
-                ],
-                "type": "non_negative_derivative"
+                "params": [],
+                "type": "non_negative_difference"
               }
             ]
           ],
@@ -1080,7 +1072,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "P4658E92B0B26FCE9"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1088,6 +1080,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -1120,7 +1114,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1155,12 +1150,11 @@
       "pluginVersion": "8.5.20",
       "targets": [
         {
-          "alias": "$tag_url-commit/rm",
+          "alias": "$tag_url-commit_add_rm",
           "datasource": {
             "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
+            "uid": "${datasource}"
           },
-          "dsType": "influxdb",
           "groupBy": [
             {
               "params": [
@@ -1204,61 +1198,7 @@
             {
               "key": "url",
               "operator": "=~",
-              "value": "/$url/"
-            }
-          ]
-        },
-        {
-          "alias": "$tag_url-commit",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
-          },
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "$Group_by_time"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "url"
-              ],
-              "type": "tag"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "puppetserver",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "B",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "file-sync-storage-service_status_experimental_metrics_average-commit-time"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "distinct"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "url",
-              "operator": "=~",
-              "value": "/$url/"
+              "value": "/^$url$/"
             }
           ]
         },
@@ -1266,9 +1206,8 @@
           "alias": "$tag_url-pre_commit_hook",
           "datasource": {
             "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
+            "uid": "${datasource}"
           },
-          "dsType": "influxdb",
           "groupBy": [
             {
               "params": [
@@ -1289,10 +1228,11 @@
               "type": "fill"
             }
           ],
+          "hide": false,
           "measurement": "puppetserver",
           "orderByTime": "ASC",
           "policy": "default",
-          "refId": "C",
+          "refId": "B",
           "resultFormat": "time_series",
           "select": [
             [
@@ -1312,7 +1252,61 @@
             {
               "key": "url",
               "operator": "=~",
-              "value": "/$url/"
+              "value": "/^$url$/"
+            }
+          ]
+        },
+        {
+          "alias": "$tag_url-commit",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${datasource}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$Group_by_time"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "url"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "puppetserver",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "file-sync-storage-service_status_experimental_metrics_average-commit-time"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "url",
+              "operator": "=~",
+              "value": "/^$url$/"
             }
           ]
         }
@@ -1323,7 +1317,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "P4658E92B0B26FCE9"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1331,6 +1325,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -1363,7 +1359,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1401,7 +1398,7 @@
           "alias": "$tag_url-commits",
           "datasource": {
             "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
+            "uid": "${datasource}"
           },
           "dsType": "influxdb",
           "groupBy": [
@@ -1459,7 +1456,7 @@
           "alias": "$tag_url-add/rm",
           "datasource": {
             "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
+            "uid": "${datasource}"
           },
           "dsType": "influxdb",
           "groupBy": [
@@ -1518,7 +1515,7 @@
           "alias": "$tag_url-pre_commit_hooks",
           "datasource": {
             "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
+            "uid": "${datasource}"
           },
           "dsType": "influxdb",
           "groupBy": [
@@ -1578,12 +1575,10 @@
       "type": "timeseries"
     }
   ],
-  "refresh": "5m",
+  "refresh": "",
   "schemaVersion": 37,
   "style": "dark",
-  "tags": [
-    "operational_dashboards"
-  ],
+  "tags": [],
   "templating": {
     "list": [
       {
@@ -1607,7 +1602,7 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": [
             "All"
           ],

--- a/files/Orchestrator_performance.json
+++ b/files/Orchestrator_performance.json
@@ -24,10 +24,10 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 57,
+  "id": 6,
+  "iteration": 1678732665217,
   "links": [
     {
-      "asDropdown": false,
       "icon": "external link",
       "includeVars": true,
       "keepTime": true,
@@ -35,10 +35,7 @@
         "operational_dashboards"
       ],
       "targetBlank": true,
-      "title": "",
-      "tooltip": "",
-      "type": "dashboards",
-      "url": ""
+      "type": "dashboards"
     }
   ],
   "liveNow": false,
@@ -46,7 +43,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "${datasource}"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -54,8 +51,270 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "^.*uptime"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ms"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.2.2",
+      "targets": [
+        {
+          "alias": "$tag_url-heap-committed",
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$Group_by_time"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "url"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "orchestrator",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "heap-memory_committed"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "url",
+              "operator": "=~",
+              "value": "/^$url$/"
+            }
+          ]
+        },
+        {
+          "alias": "$tag_url-heap-used",
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$Group_by_time"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "url"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "orchestrator",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "heap-memory_used"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "url",
+              "operator": "=~",
+              "value": "/^$url$/"
+            }
+          ]
+        },
+        {
+          "alias": "$tag_url-uptime",
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$Group_by_time"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "url"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "orchestrator",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "up-time-ms"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              },
+              {
+                "params": [
+                  "uptime"
+                ],
+                "type": "alias"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "url",
+              "operator": "=~",
+              "value": "/^$url$/"
+            }
+          ]
+        }
+      ],
+      "title": "Heap Memory and Uptime",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -97,15 +356,15 @@
               }
             ]
           },
-          "unit": "ms"
+          "unit": "short"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
-        "w": 24,
+        "h": 8,
+        "w": 12,
         "x": 0,
-        "y": 0
+        "y": 10
       },
       "id": 3,
       "links": [],
@@ -124,10 +383,9 @@
       "pluginVersion": "8.2.2",
       "targets": [
         {
-          "alias": "$tag_url-jruby-puppetserver-lock-held",
+          "alias": "$tag_url-threads",
           "datasource": {
-            "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
+            "uid": "$datasource"
           },
           "dsType": "influxdb",
           "groupBy": [
@@ -150,16 +408,18 @@
               "type": "fill"
             }
           ],
-          "measurement": "puppetserver",
+          "measurement": "orchestrator",
           "orderByTime": "ASC",
           "policy": "default",
+          "query": "SELECT distinct(\"average-requested-jrubies\") FROM \"puppetserver.jruby-metrics.average-requested-jrubies\" WHERE (\"server\" =~ /^$server$/) AND $timeFilter GROUP BY time(10s), \"server\" fill(null)",
+          "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
           "select": [
             [
               {
                 "params": [
-                  "average-lock-held-time"
+                  "threading_thread-count"
                 ],
                 "type": "field"
               },
@@ -173,15 +433,14 @@
             {
               "key": "url",
               "operator": "=~",
-              "value": "/$url/"
+              "value": "/^$url$/"
             }
           ]
         },
         {
-          "alias": "$tag_url-jruby-puppetserver-lock-wait",
+          "alias": "$tag_url-threads-max",
           "datasource": {
-            "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
+            "uid": "$datasource"
           },
           "dsType": "influxdb",
           "groupBy": [
@@ -204,16 +463,19 @@
               "type": "fill"
             }
           ],
-          "measurement": "puppetserver",
+          "hide": false,
+          "measurement": "orchestrator",
           "orderByTime": "ASC",
           "policy": "default",
+          "query": "SELECT distinct(\"average-requested-jrubies\") FROM \"puppetserver.jruby-metrics.average-requested-jrubies\" WHERE (\"server\" =~ /^$server$/) AND $timeFilter GROUP BY time(10s), \"server\" fill(null)",
+          "rawQuery": false,
           "refId": "B",
           "resultFormat": "time_series",
           "select": [
             [
               {
                 "params": [
-                  "average-lock-wait-time"
+                  "threading_peak-thread-count"
                 ],
                 "type": "field"
               },
@@ -227,18 +489,18 @@
             {
               "key": "url",
               "operator": "=~",
-              "value": "/$url/"
+              "value": "/^$url$/"
             }
           ]
         }
       ],
-      "title": "JRuby Puppet Server Lock Times",
+      "title": "Threads",
       "type": "timeseries"
     },
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "${datasource}"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -246,8 +508,6 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -282,20 +542,24 @@
               {
                 "color": "green",
                 "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
           },
-          "unit": "ms"
+          "unit": "short"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 7
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 10
       },
-      "id": 1,
+      "id": 22,
       "links": [],
       "options": {
         "legend": {
@@ -312,10 +576,9 @@
       "pluginVersion": "8.2.2",
       "targets": [
         {
-          "alias": "$tag_url-$m-clone",
+          "alias": "$tag_url-file-descriptors",
           "datasource": {
-            "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
+            "uid": "$datasource"
           },
           "dsType": "influxdb",
           "groupBy": [
@@ -338,10 +601,10 @@
               "type": "fill"
             }
           ],
-          "measurement": "/^$service$/",
+          "measurement": "orchestrator",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT distinct(\"file-sync-client-service_status_experimental_metrics_average-clone-time\") FROM /^$service$/ WHERE (\"url\" =~ /$url/) AND $timeFilter GROUP BY time($__interval), \"url\" fill(null)",
+          "query": "SELECT distinct(\"average-free-jrubies\") FROM \"puppetserver.jruby-metrics.average-free-jrubies\" WHERE (\"server\" =~ /^$server$/) AND $timeFilter GROUP BY time(10s), \"server\" fill(null)",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -349,7 +612,7 @@
             [
               {
                 "params": [
-                  "file-sync-client-service_status_experimental_metrics_average-clone-time"
+                  "file-descriptors_used"
                 ],
                 "type": "field"
               },
@@ -363,15 +626,14 @@
             {
               "key": "url",
               "operator": "=~",
-              "value": "/$url/"
+              "value": "/^$url$/"
             }
           ]
         },
         {
-          "alias": "$tag_url-$m-fetch",
+          "alias": "$tag_url-file-descriptors-max",
           "datasource": {
-            "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
+            "uid": "$datasource"
           },
           "dsType": "influxdb",
           "groupBy": [
@@ -394,16 +656,19 @@
               "type": "fill"
             }
           ],
-          "measurement": "/^$service$/",
+          "hide": false,
+          "measurement": "orchestrator",
           "orderByTime": "ASC",
           "policy": "default",
+          "query": "SELECT distinct(\"average-free-jrubies\") FROM \"puppetserver.jruby-metrics.average-free-jrubies\" WHERE (\"server\" =~ /^$server$/) AND $timeFilter GROUP BY time(10s), \"server\" fill(null)",
+          "rawQuery": false,
           "refId": "B",
           "resultFormat": "time_series",
           "select": [
             [
               {
                 "params": [
-                  "file-sync-client-service_status_experimental_metrics_average-fetch-time"
+                  "file-descriptors_max"
                 ],
                 "type": "field"
               },
@@ -417,340 +682,12 @@
             {
               "key": "url",
               "operator": "=~",
-              "value": "/$url/"
-            }
-          ]
-        },
-        {
-          "alias": "$tag_url-$m-sync_clean",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
-          },
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "$Group_by_time"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "url"
-              ],
-              "type": "tag"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "/^$service$/",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "C",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "file-sync-client-service_status_experimental_metrics_average-sync-clean-check-time"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "distinct"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "url",
-              "operator": "=~",
-              "value": "/$url/"
-            }
-          ]
-        },
-        {
-          "alias": "$tag_url-$m-sync",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
-          },
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "$Group_by_time"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "url"
-              ],
-              "type": "tag"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "/^$service$/",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "D",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "file-sync-client-service_status_experimental_metrics_average-sync-time"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "distinct"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "url",
-              "operator": "=~",
-              "value": "/$url/"
-            }
-          ]
-        },
-        {
-          "alias": "$tag_url-$m-sync-callback",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
-          },
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "$Group_by_time"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "url"
-              ],
-              "type": "tag"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "/^$service$/",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "E",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "file-sync-client-service_status_experimental_metrics_average-begin-sync-callback-time"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "distinct"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "url",
-              "operator": "=~",
-              "value": "/$url/"
-            }
-          ]
-        },
-        {
-          "alias": "$tag_url-sync-$m-end_callback",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
-          },
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "$Group_by_time"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "url"
-              ],
-              "type": "tag"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "/^$service$/",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "F",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "file-sync-client-service_status_experimental_metrics_average-end-sync-callback-time"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "distinct"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "url",
-              "operator": "=~",
-              "value": "/$url/"
-            }
-          ]
-        },
-        {
-          "alias": "$tag_url-$m-sync_prep",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
-          },
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "$Group_by_time"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "url"
-              ],
-              "type": "tag"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "/^$service$/",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "G",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "file-sync-client-service_status_experimental_metrics_average-versioned-sync-prep-time"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "distinct"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "url",
-              "operator": "=~",
-              "value": "/$url/"
-            }
-          ]
-        },
-        {
-          "alias": "$tag_url-$m-client-update",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
-          },
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "$Group_by_time"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "url"
-              ],
-              "type": "tag"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "/^$service$/",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "H",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "file-sync-client-service_status_experimental_metrics_average-client-status-update-time"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "distinct"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "url",
-              "operator": "=~",
-              "value": "/$url/"
+              "value": "/^$url$/"
             }
           ]
         }
       ],
-      "title": "Client Service Timings",
+      "title": "File Descriptors",
       "type": "timeseries"
     },
     {
@@ -764,8 +701,1218 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 9,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_url-gc-mark-sweep",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "P4658E92B0B26FCE9"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$Group_by_time"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "url"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "orchestrator",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT distinct(\"mean\") FROM \"puppetserver\" WHERE (\"url\" =~ /^$url$/ AND \"function\" != null) AND $timeFilter GROUP BY time($__interval), \"url\", \"function\" fill(null)",
+          "rawQuery": false,
+          "refId": "H",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "gc-stats_PS_MarkSweep_last-gc-info_duration-ms"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "url",
+              "operator": "=~",
+              "value": "/^$url$/"
+            }
+          ]
+        },
+        {
+          "alias": "$tag_url-gc-scavenge",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "P4658E92B0B26FCE9"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$Group_by_time"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "url"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "orchestrator",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT distinct(\"mean\") FROM \"puppetserver\" WHERE (\"url\" =~ /^$url$/ AND \"function\" != null) AND $timeFilter GROUP BY time($__interval), \"url\", \"function\" fill(null)",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "gc-stats_PS_Scavenge_last-gc-info_duration-ms"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "url",
+              "operator": "=~",
+              "value": "/^$url$/"
+            }
+          ]
+        },
+        {
+          "alias": "$tag_url-gc-old_gen",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "P4658E92B0B26FCE9"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$Group_by_time"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "url"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "orchestrator",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT distinct(\"mean\") FROM \"puppetserver\" WHERE (\"url\" =~ /^$url$/ AND \"function\" != null) AND $timeFilter GROUP BY time($__interval), \"url\", \"function\" fill(null)",
+          "rawQuery": false,
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "gc-stats_G1_Old_Generation_last-gc-info_duration-ms"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "url",
+              "operator": "=~",
+              "value": "/^$url$/"
+            }
+          ]
+        },
+        {
+          "alias": "$tag_url-gc-young_gen",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "P4658E92B0B26FCE9"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$Group_by_time"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "url"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "orchestrator",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT distinct(\"mean\") FROM \"puppetserver\" WHERE (\"url\" =~ /^$url$/ AND \"function\" != null) AND $timeFilter GROUP BY time($__interval), \"url\", \"function\" fill(null)",
+          "rawQuery": false,
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "gc-stats_G1_Young_Generation_last-gc-info_duration-ms"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "url",
+              "operator": "=~",
+              "value": "/^$url$/"
+            }
+          ]
+        }
+      ],
+      "title": "Garbage Collection Times",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 9,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_url-gc-mark-sweep",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "P4658E92B0B26FCE9"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$Group_by_time"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "url"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "orchestrator",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT distinct(\"mean\") FROM \"puppetserver\" WHERE (\"url\" =~ /^$url$/ AND \"function\" != null) AND $timeFilter GROUP BY time($__interval), \"url\", \"function\" fill(null)",
+          "rawQuery": false,
+          "refId": "H",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "gc-stats_PS_MarkSweep_count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              },
+              {
+                "params": [],
+                "type": "non_negative_difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "url",
+              "operator": "=~",
+              "value": "/^$url$/"
+            }
+          ]
+        },
+        {
+          "alias": "$tag_url-gc-scavenge",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "P4658E92B0B26FCE9"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$Group_by_time"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "url"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "orchestrator",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT distinct(\"mean\") FROM \"puppetserver\" WHERE (\"url\" =~ /^$url$/ AND \"function\" != null) AND $timeFilter GROUP BY time($__interval), \"url\", \"function\" fill(null)",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "gc-stats_PS_Scavenge_count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              },
+              {
+                "params": [],
+                "type": "non_negative_difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "url",
+              "operator": "=~",
+              "value": "/^$url$/"
+            }
+          ]
+        },
+        {
+          "alias": "$tag_url-gc-old_gen",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "P4658E92B0B26FCE9"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$Group_by_time"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "url"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "orchestrator",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT distinct(\"mean\") FROM \"puppetserver\" WHERE (\"url\" =~ /^$url$/ AND \"function\" != null) AND $timeFilter GROUP BY time($__interval), \"url\", \"function\" fill(null)",
+          "rawQuery": false,
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "gc-stats_G1_Old_Generation_count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              },
+              {
+                "params": [],
+                "type": "non_negative_difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "url",
+              "operator": "=~",
+              "value": "/^$url$/"
+            }
+          ]
+        },
+        {
+          "alias": "$tag_url-gc-young_gen",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "P4658E92B0B26FCE9"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$Group_by_time"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "url"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "orchestrator",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT distinct(\"mean\") FROM \"puppetserver\" WHERE (\"url\" =~ /^$url$/ AND \"function\" != null) AND $timeFilter GROUP BY time($__interval), \"url\", \"function\" fill(null)",
+          "rawQuery": false,
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "gc-stats_G1_Young_Generation_count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              },
+              {
+                "params": [],
+                "type": "non_negative_difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "url",
+              "operator": "=~",
+              "value": "/^$url$/"
+            }
+          ]
+        }
+      ],
+      "title": "Garbage Collection Counts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 9,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_url-[[tag_route-id]]-mean",
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "url"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "route-id"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "orchestrator",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT distinct(\"mean\") FROM \"orchestrator\" WHERE (\"url\" =~ /^$url$/ AND \"route-id\" != null AND \"route-id\" !~ /total$/) AND $timeFilter GROUP BY time($Group_by_time), \"url\", \"route-id\" fill(null)",
+          "rawQuery": true,
+          "refId": "H",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "mean"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "url",
+              "operator": "=~",
+              "value": "/^$url$/"
+            }
+          ]
+        }
+      ],
+      "title": "Route Times",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 9,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 26
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_url-[[tag_route-id]]-count",
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "url"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "route-id"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "orchestrator",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT non_negative_difference(distinct(\"count\")) FROM \"orchestrator\" WHERE (\"url\" =~ /^$url$/ AND \"route-id\" != null AND \"route-id\" !~ /total$/) AND $timeFilter GROUP BY time($Group_by_time), \"url\", \"route-id\" fill(null)",
+          "rawQuery": true,
+          "refId": "H",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              },
+              {
+                "params": [],
+                "type": "non_negative_difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "url",
+              "operator": "=~",
+              "value": "/^$url$/"
+            }
+          ]
+        }
+      ],
+      "title": "Route Counts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ns"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "id": 25,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.2.2",
+      "targets": [
+        {
+          "alias": "$tag_url-on_close",
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$Group_by_time"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "url"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "orchestrator",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT distinct(\"average-requested-jrubies\") FROM \"puppetserver.jruby-metrics.average-requested-jrubies\" WHERE (\"server\" =~ /^$server$/) AND $timeFilter GROUP BY time(10s), \"server\" fill(null)",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "puppetlabs.pcp.on-close_mean"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "url",
+              "operator": "=~",
+              "value": "/^$url$/"
+            }
+          ]
+        },
+        {
+          "alias": "$tag_url-on_connect",
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$Group_by_time"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "url"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "orchestrator",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT distinct(\"average-requested-jrubies\") FROM \"puppetserver.jruby-metrics.average-requested-jrubies\" WHERE (\"server\" =~ /^$server$/) AND $timeFilter GROUP BY time(10s), \"server\" fill(null)",
+          "rawQuery": false,
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "puppetlabs.pcp.on-connect_mean"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "url",
+              "operator": "=~",
+              "value": "/^$url$/"
+            }
+          ]
+        },
+        {
+          "alias": "$tag_url-on_message",
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$Group_by_time"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "url"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "orchestrator",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT distinct(\"average-requested-jrubies\") FROM \"puppetserver.jruby-metrics.average-requested-jrubies\" WHERE (\"server\" =~ /^$server$/) AND $timeFilter GROUP BY time(10s), \"server\" fill(null)",
+          "rawQuery": false,
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "puppetlabs.pcp.on-message_mean"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "url",
+              "operator": "=~",
+              "value": "/^$url$/"
+            }
+          ]
+        },
+        {
+          "alias": "$tag_url-on_message",
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$Group_by_time"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "url"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "orchestrator",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT distinct(\"average-requested-jrubies\") FROM \"puppetserver.jruby-metrics.average-requested-jrubies\" WHERE (\"server\" =~ /^$server$/) AND $timeFilter GROUP BY time(10s), \"server\" fill(null)",
+          "rawQuery": false,
+          "refId": "D",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "puppetlabs.pcp.on-send_mean"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "url",
+              "operator": "=~",
+              "value": "/^$url$/"
+            }
+          ]
+        }
+      ],
+      "title": "PCP Times",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -812,12 +1959,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 14
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 35
       },
-      "id": 4,
+      "id": 26,
       "links": [],
       "options": {
         "legend": {
@@ -834,11 +1981,11 @@
       "pluginVersion": "8.2.2",
       "targets": [
         {
-          "alias": "$tag_url-$m-fetch",
+          "alias": "$tag_url-on_close",
           "datasource": {
-            "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
+            "uid": "$datasource"
           },
+          "dsType": "influxdb",
           "groupBy": [
             {
               "params": [
@@ -859,89 +2006,24 @@
               "type": "fill"
             }
           ],
-          "hide": false,
-          "measurement": "/^$service$/",
+          "measurement": "orchestrator",
           "orderByTime": "ASC",
           "policy": "default",
-          "refId": "B",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "file-sync-client-service_status_experimental_metrics_num-fetches"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "distinct"
-              },
-              {
-                "params": [
-                  "$__interval"
-                ],
-                "type": "non_negative_derivative"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "url",
-              "operator": "=~",
-              "value": "/^$url$/"
-            }
-          ]
-        },
-        {
-          "alias": "$tag_url-$m-clone",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "$Group_by_time"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "url"
-              ],
-              "type": "tag"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "/^$service$/",
-          "orderByTime": "ASC",
-          "policy": "default",
+          "query": "SELECT distinct(\"average-requested-jrubies\") FROM \"puppetserver.jruby-metrics.average-requested-jrubies\" WHERE (\"server\" =~ /^$server$/) AND $timeFilter GROUP BY time(10s), \"server\" fill(null)",
+          "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
           "select": [
             [
               {
                 "params": [
-                  "file-sync-client-service_status_experimental_metrics_num-clones"
+                  "puppetlabs.pcp.on-close_rates_5"
                 ],
                 "type": "field"
               },
               {
                 "params": [],
                 "type": "distinct"
-              },
-              {
-                "params": [
-                  "$__interval"
-                ],
-                "type": "non_negative_derivative"
               }
             ]
           ],
@@ -954,11 +2036,11 @@
           ]
         },
         {
-          "alias": "$tag_url-$m-sync",
+          "alias": "$tag_url-on_connect",
           "datasource": {
-            "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
+            "uid": "$datasource"
           },
+          "dsType": "influxdb",
           "groupBy": [
             {
               "params": [
@@ -980,28 +2062,80 @@
             }
           ],
           "hide": false,
-          "measurement": "/^$service$/",
+          "measurement": "orchestrator",
           "orderByTime": "ASC",
           "policy": "default",
+          "query": "SELECT distinct(\"average-requested-jrubies\") FROM \"puppetserver.jruby-metrics.average-requested-jrubies\" WHERE (\"server\" =~ /^$server$/) AND $timeFilter GROUP BY time(10s), \"server\" fill(null)",
+          "rawQuery": false,
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "puppetlabs.pcp.on-connect_rates_5"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "url",
+              "operator": "=~",
+              "value": "/^$url$/"
+            }
+          ]
+        },
+        {
+          "alias": "$tag_url-on_message",
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$Group_by_time"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "url"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "orchestrator",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT distinct(\"average-requested-jrubies\") FROM \"puppetserver.jruby-metrics.average-requested-jrubies\" WHERE (\"server\" =~ /^$server$/) AND $timeFilter GROUP BY time(10s), \"server\" fill(null)",
+          "rawQuery": false,
           "refId": "C",
           "resultFormat": "time_series",
           "select": [
             [
               {
                 "params": [
-                  "file-sync-client-service_status_experimental_metrics_num-syncs"
+                  "puppetlabs.pcp.on-message_rates_5"
                 ],
                 "type": "field"
               },
               {
                 "params": [],
                 "type": "distinct"
-              },
-              {
-                "params": [
-                  "$__interval"
-                ],
-                "type": "non_negative_derivative"
               }
             ]
           ],
@@ -1014,11 +2148,11 @@
           ]
         },
         {
-          "alias": "$tag_url-$m-sync-clean",
+          "alias": "$tag_url-on_send",
           "datasource": {
-            "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
+            "uid": "$datasource"
           },
+          "dsType": "influxdb",
           "groupBy": [
             {
               "params": [
@@ -1040,28 +2174,24 @@
             }
           ],
           "hide": false,
-          "measurement": "puppetserver",
+          "measurement": "orchestrator",
           "orderByTime": "ASC",
           "policy": "default",
+          "query": "SELECT distinct(\"average-requested-jrubies\") FROM \"puppetserver.jruby-metrics.average-requested-jrubies\" WHERE (\"server\" =~ /^$server$/) AND $timeFilter GROUP BY time(10s), \"server\" fill(null)",
+          "rawQuery": false,
           "refId": "D",
           "resultFormat": "time_series",
           "select": [
             [
               {
                 "params": [
-                  "file-sync-client-service_status_experimental_metrics_num-sync-clean-checks"
+                  "puppetlabs.pcp.on-send_rates_5"
                 ],
                 "type": "field"
               },
               {
                 "params": [],
                 "type": "distinct"
-              },
-              {
-                "params": [
-                  "$__interval"
-                ],
-                "type": "non_negative_derivative"
               }
             ]
           ],
@@ -1074,516 +2204,14 @@
           ]
         }
       ],
-      "title": "Client Service Counts",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "P4658E92B0B26FCE9"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "dtdurationms"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 21
-      },
-      "id": 2,
-      "links": [],
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "8.5.20",
-      "targets": [
-        {
-          "alias": "$tag_url-commit/rm",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
-          },
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "$Group_by_time"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "url"
-              ],
-              "type": "tag"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "puppetserver",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "file-sync-storage-service_status_experimental_metrics_average-commit-add-rm-time"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "distinct"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "url",
-              "operator": "=~",
-              "value": "/$url/"
-            }
-          ]
-        },
-        {
-          "alias": "$tag_url-commit",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
-          },
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "$Group_by_time"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "url"
-              ],
-              "type": "tag"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "puppetserver",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "B",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "file-sync-storage-service_status_experimental_metrics_average-commit-time"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "distinct"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "url",
-              "operator": "=~",
-              "value": "/$url/"
-            }
-          ]
-        },
-        {
-          "alias": "$tag_url-pre_commit_hook",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
-          },
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "$Group_by_time"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "url"
-              ],
-              "type": "tag"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "puppetserver",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "C",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "file-sync-storage-service_status_experimental_metrics_average-pre-commit-hook-time"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "distinct"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "url",
-              "operator": "=~",
-              "value": "/$url/"
-            }
-          ]
-        }
-      ],
-      "title": "Storage Service Timings",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "P4658E92B0B26FCE9"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 28
-      },
-      "id": 7,
-      "links": [],
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "8.5.20",
-      "targets": [
-        {
-          "alias": "$tag_url-commits",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
-          },
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "$Group_by_time"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "url"
-              ],
-              "type": "tag"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "puppetserver",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "file-sync-storage-service_status_experimental_metrics_num-commits"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "distinct"
-              },
-              {
-                "params": [],
-                "type": "non_negative_difference"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "url",
-              "operator": "=~",
-              "value": "/$url/"
-            }
-          ]
-        },
-        {
-          "alias": "$tag_url-add/rm",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
-          },
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "$Group_by_time"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "url"
-              ],
-              "type": "tag"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "puppetserver",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "B",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "file-sync-storage-service_status_experimental_metrics_num-commit-add-rm-ops"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "distinct"
-              },
-              {
-                "params": [],
-                "type": "non_negative_difference"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "url",
-              "operator": "=~",
-              "value": "/$url/"
-            }
-          ]
-        },
-        {
-          "alias": "$tag_url-pre_commit_hooks",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "P4658E92B0B26FCE9"
-          },
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "$Group_by_time"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "url"
-              ],
-              "type": "tag"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "puppetserver",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "C",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "file-sync-storage-service_status_experimental_metrics_num-pre-commit-hook-ops"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "distinct"
-              },
-              {
-                "params": [],
-                "type": "non_negative_difference"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "url",
-              "operator": "=~",
-              "value": "/$url/"
-            }
-          ]
-        }
-      ],
-      "title": "Storage Service Counts",
+      "title": "PCP Counts",
       "type": "timeseries"
     }
   ],
   "refresh": "5m",
-  "schemaVersion": 37,
+  "schemaVersion": 36,
   "style": "dark",
-  "tags": [
-    "operational_dashboards"
-  ],
+  "tags": [],
   "templating": {
     "list": [
       {
@@ -1607,7 +2235,7 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": [
             "All"
           ],
@@ -1635,43 +2263,6 @@
         "tagsQuery": "",
         "type": "query",
         "useTags": false
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
-        },
-        "hide": 0,
-        "includeAll": true,
-        "label": "service",
-        "multi": true,
-        "name": "service",
-        "options": [
-          {
-            "selected": true,
-            "text": "All",
-            "value": "$__all"
-          },
-          {
-            "selected": false,
-            "text": "puppetserver",
-            "value": "puppetserver"
-          },
-          {
-            "selected": false,
-            "text": "orchestrator",
-            "value": "orchestrator"
-          }
-        ],
-        "query": "puppetserver,orchestrator",
-        "queryValue": "",
-        "skipUrlSync": false,
-        "type": "custom"
       },
       {
         "auto": false,
@@ -1779,5 +2370,5 @@
     ]
   },
   "timezone": "utc",
-  "title": "Filesync Performance"
+  "title": "Orchestrator Performance"
 }

--- a/files/plan_files/orchestrator.conf
+++ b/files/plan_files/orchestrator.conf
@@ -36,7 +36,7 @@ def apply(metric):
     metric = Metric("orchestrator")
     metric.time = date
     metric.tags['url'] = server
-    recurse_dict(subdict, None, metric, [])
+    recurse_dict(subdict, 'file-sync-client-service_status_experimental_metrics', metric, [])
     metrics.append(metric)
 
   if 'metrics' in d['servers'][server]['orchestrator']['broker-service']['status']:

--- a/files/plan_files/orchestrator.conf
+++ b/files/plan_files/orchestrator.conf
@@ -1,0 +1,88 @@
+[[inputs.file]]
+data_format = "value"
+data_type = "string"
+files = ["./metrics/orchestrator/**json"]
+[inputs.file.tags]
+type = 'orchestrator'
+
+[[processors.starlark]]
+namepass = ["file"]
+source = '''
+load("json.star", "json")
+load("time.star", "time")
+
+def apply(metric):
+  d = json.decode(metric.fields['value'])
+  server = d['servers'].keys()[0]
+  timestamp = d['timestamp']
+  date = time.parse_time(d['timestamp'], location="UTC").unix_nano
+  metrics = []
+
+  if 'status-service' not in d['servers'][server]['orchestrator']:
+    return
+
+  if 'jvm-metrics' in d['servers'][server]['orchestrator']['status-service']['status']['experimental']:
+    subdict = d['servers'][server]['orchestrator']['status-service']['status']['experimental']['jvm-metrics']
+
+    metric = Metric("orchestrator")
+    metric.time = date
+    metric.tags['url'] = server
+
+    recurse_dict(subdict, None, metric, [])
+    metrics.append(metric)
+
+  if 'file-sync-client-service' in d['servers'][server]['orchestrator']:
+    subdict = d['servers'][server]['orchestrator']['file-sync-client-service']['status']['experimental']['metrics']
+    metric = Metric("orchestrator")
+    metric.time = date
+    metric.tags['url'] = server
+    recurse_dict(subdict, None, metric, [])
+    metrics.append(metric)
+
+  if 'metrics' in d['servers'][server]['orchestrator']['broker-service']['status']:
+    subdict = d['servers'][server]['orchestrator']['broker-service']['status']['metrics']
+    metric = Metric("orchestrator")
+    metric.time = date
+    metric.tags['url'] = server
+    recurse_dict(subdict, None, metric, [])
+    metrics.append(metric)
+
+  if 'sorted-routes' in d['servers'][server]['orchestrator']['orchestrator-service']['status']['metrics']['routes']:
+    m = d['servers'][server]['orchestrator']['orchestrator-service']['status']['metrics']['routes']['sorted-routes']
+
+    route_metrics = iterate_metric_array(m, 'route-id', ['count', 'mean', 'aggregate'])
+
+    for metric in route_metrics:
+      metric.time = date
+      metric.tags['url'] = server
+      metrics.append(metric)
+
+  return metrics
+
+def recurse_dict(dict, tags, metric, skip_fields):
+  for k,v in dict.items():
+    if k in skip_fields:
+      continue
+    if type(v) == 'dict':
+      recurse_dict(v, k if tags == None else tags + "_{0}".format(k), metric, skip_fields)
+    else:
+      field = tags + "_" + k if tags else k
+      metric.fields[field.replace(' ', '_')] = v
+
+def iterate_metric_array(metric_array, tag_field, fields):
+  local_metrics = []
+
+  for d in metric_array:
+    metric = Metric("orchestrator")
+    metric.tags[tag_field] = d[tag_field]
+
+    for field in fields:
+      metric.fields[field] = d[field]
+
+    local_metrics.append(metric)
+
+  return local_metrics
+
+'''
+[processors.starlark.tagpass]
+type = ['orchestrator']

--- a/files/plan_files/puppetserver.conf
+++ b/files/plan_files/puppetserver.conf
@@ -101,6 +101,30 @@ def apply(metric):
       metric.tags['url'] = server
       metrics.append(metric)
 
+  # The file sync storage fields are special because they are "additional metrics" in the collector
+  # Here we use the field names returned by the /metrics/v2 api
+  if 'file-sync-storage-commit-timer' in d['servers'][server]['puppetserver']:
+    metric = Metric("puppetserver")
+    metric.time = date
+    metric.tags['url'] = server
+
+    val = d['servers'][server]['puppetserver']['file-sync-storage-commit-timer'].values()
+    if val:
+      metric.fields['file-sync-storage-service_status_experimental_metrics_average-commit-time'] = val[0]["Mean"]
+      metric.fields['file-sync-storage-service_status_experimental_metrics_num-commits'] = val[0]["Count"]
+
+    val = d['servers'][server]['puppetserver']['file-sync-storage-pre-commit-hook-timer'].values()
+    if val:
+      metric.fields['file-sync-storage-service_status_experimental_metrics_average-pre-commit-hook-time'] = val[0]["Mean"]
+      metric.fields['file-sync-storage-service_status_experimental_metrics_num-pre-commit-hook-ops'] = val[0]["Count"]
+
+    val = d['servers'][server]['puppetserver']['file-sync-storage-commit-add-rm-timer'].values()
+    if val:
+      metric.fields['file-sync-storage-service_status_experimental_metrics_average-commit-add-rm-time'] = val[0]["Mean"]
+      metric.fields['file-sync-storage-service_status_experimental_metrics_num-commit-add-rm-ops'] = val[0]["Count"]
+
+    metrics.append(metric)
+
   # Why does this one have to be different
   if 'jruby-metrics' in d['servers'][server]['puppetserver']:
     m = d['servers'][server]['puppetserver']['jruby-metrics']['status']['experimental']['metrics']

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,6 +35,8 @@
 #   as well Deferred functions in this module.
 # @param telegraf_token
 #   Telegraf token in Sensitive format.
+# @param include_pe_metrics
+#   Whether to include Filesync and Orchestrator dashboards
 class puppet_operational_dashboards (
   Boolean $manage_influxdb = true,
   String $influxdb_host = lookup(influxdb::host, undef, undef, $facts['networking']['fqdn']),
@@ -53,6 +55,8 @@ class puppet_operational_dashboards (
   Boolean $manage_telegraf = true,
   Boolean $manage_telegraf_token = true,
   Boolean $use_ssl = true,
+  # Check for PE by looking at the compiling server's module_groups setting
+  Boolean $include_pe_metrics = $settings::module_groups =~ 'pe_only',
 ) {
   unless $facts['os']['family'] in ['RedHat', 'Debian', 'Suse'] {
     fail("Installation on ${facts['os']['family']} is not supported")

--- a/manifests/telegraf/config.pp
+++ b/manifests/telegraf/config.pp
@@ -16,7 +16,7 @@ define puppet_operational_dashboards::telegraf::config (
   String $service = $title,
   Enum['present', 'absent'] $ensure = 'present',
 ) {
-  unless $service in ['puppetserver', 'puppetdb', 'puppetdb_jvm'] {
+  unless $service in ['puppetserver', 'puppetdb', 'puppetdb_jvm', 'orchestrator'] {
     fail("Unknown service type ${service}")
   }
 
@@ -25,6 +25,7 @@ define puppet_operational_dashboards::telegraf::config (
       'puppetdb'     => '8081/metrics/v2/read',
       'puppetdb_jvm'     => '8081/status/v1/services?level=debug',
       'puppetserver'     => '8140/status/v1/services?level=debug',
+      'orchestrator'     => '8143/status/v1/services?level=debug',
     }
 
     # Create a urls[] array with literal quotes around each entry

--- a/plans/load_metrics.pp
+++ b/plans/load_metrics.pp
@@ -122,7 +122,15 @@ plan puppet_operational_dashboards::load_metrics (
     file { "${conf_dir}/telegraf.conf.d":
       ensure => directory,
     }
-    ['postgres.conf', 'puppetdb.conf', 'puppetserver.conf', 'system_cpu.conf', 'system_memory.conf', 'system_procs.conf'].each |$script| {
+    [
+      'postgres.conf',
+      'puppetdb.conf',
+      'puppetserver.conf',
+      'system_cpu.conf',
+      'system_memory.conf',
+      'system_procs.conf',
+      'orchestrator.conf',
+    ].each |$script| {
       file { "${conf_dir}/telegraf.conf.d/${script}":
         ensure => file,
         source => "puppet:///modules/puppet_operational_dashboards/plan_files/${script}",

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -10,6 +10,7 @@ describe 'puppet_operational_dashboards::telegraf::agent' do
       function puppet_operational_dashboards::hosts_with_profile($profile) { return ['localhost.foo.com'] }
       class{ 'puppet_operational_dashboards':
         influxdb_host => 'localhost.foo.com',
+        include_pe_metrics => true,
       }
     PRE_COND
   end
@@ -111,6 +112,7 @@ describe 'puppet_operational_dashboards::telegraf::agent' do
         class{ 'puppet_operational_dashboards':
           influxdb_host => 'localhost.foo.com',
           use_ssl       => false,
+          include_pe_metrics => true,
         }
       PRE_COND
     end

--- a/spec/classes/dashboards_spec.rb
+++ b/spec/classes/dashboards_spec.rb
@@ -2,7 +2,13 @@ require 'spec_helper'
 
 describe 'puppet_operational_dashboards::profile::dashboards' do
   let(:facts) { { os: { family: 'RedHat' } } }
-  let(:pre_condition) { 'include puppet_operational_dashboards' }
+  let(:pre_condition) do
+    <<-PRE_COND
+      class{ 'puppet_operational_dashboards':
+        include_pe_metrics => true,
+      }
+    PRE_COND
+  end
 
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
@@ -35,7 +41,7 @@ describe 'puppet_operational_dashboards::profile::dashboards' do
       is_expected.to contain_file('/etc/grafana/provisioning/datasources/influxdb.yaml').that_requires('Class[grafana::install]')
       is_expected.to contain_file('/etc/grafana/provisioning/datasources/influxdb.yaml').that_notifies('Service[grafana-server]')
 
-      ['Filesync Performance', 'Postgresql Performance', 'Puppetdb Performance', 'Puppetserver Performance'].each do |dashboard|
+      ['Filesync Performance', 'Postgresql Performance', 'Puppetdb Performance', 'Puppetserver Performance', 'Orchestrator Performance'].each do |dashboard|
         is_expected.to contain_grafana_dashboard(dashboard).that_requires('Class[grafana::install]')
       end
 
@@ -62,7 +68,8 @@ describe 'puppet_operational_dashboards::profile::dashboards' do
         influxdb_bucket: 'puppet_data',
         telegraf_token_name: 'puppet telegraf token',
         influxdb_token_file: '/root/.influxdb_token',
-        manage_grafana: false
+        manage_grafana: false,
+        include_pe_metrics: true,
       }
     end
 
@@ -72,7 +79,7 @@ describe 'puppet_operational_dashboards::profile::dashboards' do
       is_expected.not_to contain_file('grafana-conf-d')
 
       # We expect the dashboards to be managed, but to not require the install class
-      ['Filesync Performance', 'Postgresql Performance', 'Puppetdb Performance', 'Puppetserver Performance'].each do |dashboard|
+      ['Filesync Performance', 'Postgresql Performance', 'Puppetdb Performance', 'Puppetserver Performance', 'Orchestrator Performance'].each do |dashboard|
         is_expected.to contain_grafana_dashboard(dashboard)
         is_expected.not_to contain_grafana_dashboard(dashboard).that_requires('Class[grafana::install]')
       end
@@ -90,6 +97,7 @@ describe 'puppet_operational_dashboards::profile::dashboards' do
         influxdb_bucket: 'puppet_data',
         telegraf_token_name: 'puppet telegraf token',
         influxdb_token_file: '/root/.influxdb_token',
+        include_pe_metrics: true,
       }
     end
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -6,13 +6,14 @@ describe 'puppet_operational_dashboards' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
+      let(:params) { { include_pe_metrics: true } }
 
       it { is_expected.to compile }
     end
   end
 
   context 'when using default parameters' do
-    let(:params) { { influxdb_host: 'localhost' } }
+    let(:params) { { influxdb_host: 'localhost', include_pe_metrics: true } }
 
     it {
       is_expected.to contain_class('puppet_operational_dashboards::profile::dashboards')
@@ -79,13 +80,13 @@ describe 'puppet_operational_dashboards' do
   end
 
   context 'when not using ssl' do
-    let(:params) { { influxdb_host: 'localhost', use_ssl: false } }
+    let(:params) { { influxdb_host: 'localhost', use_ssl: false, include_pe_metrics: true } }
 
     it { is_expected.to contain_class('influxdb').with(use_ssl: false) }
   end
 
   context 'when not managing influxdb' do
-    let(:params) { { influxdb_host: 'localhost', manage_influxdb: false } }
+    let(:params) { { influxdb_host: 'localhost', manage_influxdb: false, include_pe_metrics: true } }
 
     it {
       is_expected.not_to contain_class('influxdb')
@@ -99,7 +100,7 @@ describe 'puppet_operational_dashboards' do
   end
 
   context 'when not managing telegraf' do
-    let(:params) { { manage_telegraf: false } }
+    let(:params) { { manage_telegraf: false, include_pe_metrics: true } }
 
     it {
       is_expected.not_to contain_class('puppet_operational_dashboards::telegraf::agent')
@@ -107,7 +108,7 @@ describe 'puppet_operational_dashboards' do
   end
 
   context 'when not managing telegraf token' do
-    let(:params) { { manage_telegraf_token: false } }
+    let(:params) { { manage_telegraf_token: false, include_pe_metrics: true } }
 
     it {
       is_expected.not_to contain_influxdb_auth('puppet telegraf token')
@@ -115,7 +116,7 @@ describe 'puppet_operational_dashboards' do
   end
 
   context 'when passing a token' do
-    let(:params) { { influxdb_host: 'localhost', influxdb_token: RSpec::Puppet::Sensitive.new('puppetlabs') } }
+    let(:params) { { influxdb_host: 'localhost', influxdb_token: RSpec::Puppet::Sensitive.new('puppetlabs'), include_pe_metrics: true } }
 
     it {
       is_expected.to contain_influxdb_org('puppetlabs').with(token: RSpec::Puppet::Sensitive.new('puppetlabs'))

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -9,4 +9,6 @@ macaddress: "AA:AA:AA:AA:AA:AA"
 pe_build: 2021.5.0
 identity:
   user: root
+settings:
+  module_groups: base+pe_only
 

--- a/templates/orchestrator_metrics.epp
+++ b/templates/orchestrator_metrics.epp
@@ -1,0 +1,30 @@
+<%- | Array[String] $urls, Enum['https', 'http'] $protocol, Integer[1] $http_timeout_seconds | -%>
+<% if $protocol == 'https' { -%>
+tls_cert = "/etc/telegraf/cert.pem"
+tls_key = "/etc/telegraf/key.pem"
+tls_ca = "/etc/telegraf/ca.pem"
+<% } -%>
+data_format = "json_v2"
+headers = {"Content-type" = "application/json"}
+method = 'GET'
+timeout = "<%= $http_timeout_seconds %>s"
+urls = <%= $urls %>
+[[json_v2]]
+   measurement_name = "orchestrator"
+   [[json_v2.object]]
+      disable_prepend_keys = false
+      path = "status-service.status.experimental.jvm-metrics"
+   [[json_v2.object]]
+      disable_prepend_keys = false
+      path = "broker-service.status.metrics"
+   [[json_v2.object]]
+      disable_prepend_keys = true
+      path = "orchestrator-service.status.metrics.routes.sorted-routes"
+      tags = ["route-id"]
+   [[json_v2.object]]
+      disable_prepend_keys = true
+      path = "orchestrator-service.status.metrics.app"
+   [[json_v2.object]]
+      disable_prepend_keys = false
+      path = "@this"
+      included_keys = ["file-sync-client-service_status_experimental_metrics_average-begin-sync-callback-time", "file-sync-client-service_status_experimental_metrics_average-clone-time", "file-sync-client-service_status_experimental_metrics_average-live-dir-update-time", "file-sync-client-service_status_experimental_metrics_average-versioned-sync-prep-time", "file-sync-client-service_status_experimental_metrics_average-sync-clean-check-time", "file-sync-client-service_status_experimental_metrics_num-clones", "file-sync-client-service_status_experimental_metrics_average-versioned-sync-cleanup-time", "file-sync-client-service_status_experimental_metrics_average-client-status-update-time", "file-sync-client-service_status_experimental_metrics_average-fetch-time", "file-sync-client-service_status_experimental_metrics_average-end-sync-callback-time", "file-sync-client-service_status_experimental_metrics_average-sync-time", "file-sync-client-service_status_experimental_metrics_num-syncs", "file-sync-client-service_status_experimental_metrics_num-sync-clean-checks", "file-sync-client-service_status_experimental_metrics_num-fetches", "file-sync-storage-service_status_experimental_metrics_num-commits", "file-sync-storage-service_status_experimental_metrics_average-commit-time", "file-sync-storage-service_status_experimental_metrics_num-commit-add-rm-ops", "file-sync-storage-service_status_experimental_metrics_num-pre-commit-hook-ops", "file-sync-storage-service_status_experimental_metrics_average-commit-add-rm-time", "file-sync-storage-service_status_experimental_metrics_average-pre-commit-hook-time"]


### PR DESCRIPTION
This commit adds a Grafana dashboard and Telegraf config for gathering and displaying Orchestrator metrics in PE.  It also adds its file sync client metrics to the Filesync dashboard, as well as file sync storage metrics for Puppet server