### PR TITLE
pe_profiles_on_host: Fix orchestrator support

### DIFF
--- a/functions/pe_profiles_on_host.pp
+++ b/functions/pe_profiles_on_host.pp
@@ -10,7 +10,7 @@ function puppet_operational_dashboards::pe_profiles_on_host() >> Array[String] {
   $hosts = puppetdb_query("resources[title] {
       type = 'Class' and
       certname = '${trusted['certname']}' and
-      title in ['Puppet_enterprise::Profile::Puppetdb', 'Puppet_enterprise::Profile::Master', 'Puppet_enterprise::Profile::Database'] and
+      title in ['Puppet_enterprise::Profile::Puppetdb', 'Puppet_enterprise::Profile::Master', 'Puppet_enterprise::Profile::Database', 'Puppet_enterprise::Profile::Orchestrator'] and
       nodes { deactivated is null and expired is null }
     }").map |$nodes| { $nodes['title'] }
   } else {


### PR DESCRIPTION
https://github.com/puppetlabs/puppet_operational_dashboards/commit/ddfbe15cbd3fea11175528ce12a14f7ec94b7927 implemented support for Orchestrator metrics. The function pe_profiles_on_host is used to determine of the orchestrator profile is present on a node. The list of possible classes is hardcoded in the function and needs to be extended.