### PR TITLE
Allow disabling of System Performance dashboard creation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,8 @@
 #   Telegraf token in Sensitive format.
 # @param include_pe_metrics
 #   Whether to include Filesync and Orchestrator dashboards
+# @param manage_system_board
+#   Whether the System Performance dashboard should be added to grafana
 class puppet_operational_dashboards (
   Boolean $manage_influxdb = true,
   String $influxdb_host = lookup(influxdb::host, undef, undef, $facts['networking']['fqdn']),
@@ -57,6 +59,7 @@ class puppet_operational_dashboards (
   Boolean $use_ssl = true,
   # Check for PE by looking at the compiling server's module_groups setting
   Boolean $include_pe_metrics = $settings::module_groups =~ 'pe_only',
+  Boolean $manage_system_board = true,
 ) {
   unless $facts['os']['family'] in ['RedHat', 'Debian', 'Suse'] {
     fail("Installation on ${facts['os']['family']} is not supported")

--- a/manifests/profile/dashboards.pp
+++ b/manifests/profile/dashboards.pp
@@ -48,6 +48,8 @@
 #   Location on disk to store datasource definition
 # @param include_pe_metrics
 #   Whether to include Filesync and Orchestrator dashboards
+# @param manage_system_board
+#   Whether the System Performance dashboard should be created
 class puppet_operational_dashboards::profile::dashboards (
   Optional[Sensitive[String]] $token = $puppet_operational_dashboards::telegraf_token,
   String $grafana_host = $facts['networking']['fqdn'],
@@ -71,6 +73,7 @@ class puppet_operational_dashboards::profile::dashboards (
   String $telegraf_token_name = $puppet_operational_dashboards::telegraf_token_name,
   String $influxdb_token_file = $puppet_operational_dashboards::influxdb_token_file,
   Boolean $include_pe_metrics = $puppet_operational_dashboards::include_pe_metrics,
+  Boolean $manage_system_board = $puppet_opertational_dashboards::manage_system_board,
 ) {
   $grafana_url = "http://${grafana_host}:${grafana_port}"
 
@@ -156,12 +159,21 @@ class puppet_operational_dashboards::profile::dashboards (
     }
   }
 
-  ['Puppetserver', 'Puppetdb', 'Postgresql', 'System'].each |$service| {
+  ['Puppetserver', 'Puppetdb', 'Postgresql'].each |$service| {
     grafana_dashboard { "${service} Performance":
       grafana_user     => 'admin',
       grafana_password => $grafana_password.unwrap,
       grafana_url      => $grafana_url,
       content          => file("puppet_operational_dashboards/${service}_performance.json"),
+    }
+  }
+
+  if $manage_system_board {
+    grafana_dashboard { 'System Performance':
+      grafana_user     => 'admin',
+      grafana_password => $grafana_password.unwrap,
+      grafana_url      => $grafana_url,
+      content          => file('puppet_operational_dashboards/System_performance.json'),
     }
   }
 


### PR DESCRIPTION
The System Performance dashbord gets created but is always empty. There is no description of inputs configuration in telegraf needed to fill the board with data.
The puppet_metrics_collector is able to push system metrics, but can not deal with SSL encrypted influxdb connection.

This empty dashboard confuses PE and Puppet Open Source customers, as they expect data to show up.

This PR allows disabling of creating the System Performance dashboard by specifying the parameter `manage_system_board`.