### PR TITLE
(SUP-3952) Remove Puppet 6 as a supported platform

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -35,44 +35,61 @@
   ],
   "operatingsystem_support": [
     {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "7",
+        "8"
+      ]
+    },
+    {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "8",
         "7"
       ]
     },
     {
-      "operatingsystem": "Debian",
+      "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "10",
-        "9"
+        "7"
       ]
     },
     {
-      "operatingsystem": "RedHat",
+      "operatingsystem": "Scientific",
       "operatingsystemrelease": [
-        "8",
         "7"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "20.04",
-        "18.04"
+        "18.04",
+        "20.04"
       ]
     },
     {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
-        "12"
+        "12",
+        "15"
+      ]
+    },
+    {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "RockyLinux",
+      "operatingsystemrelease": [
+        "8"
       ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 8.0.0"
     }
   ],
   "pdk-version": "2.6.1",


### PR DESCRIPTION
Update to puppet 7 and update supported OS