### PR TITLE
Bump dependency for inifile

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppetlabs-inifile",
-      "version_requirement": ">= 2.0.0 < 6.0.0"
+      "version_requirement": ">= 2.0.0 < 7.0.0"
     },
     {
       "name": "puppetlabs-influxdb",


### PR DESCRIPTION
A new version of this module was released to add Puppet 8 support, so bump the dependency in this module to account for it.