### PR TITLE
puppet/telegraf: Require 5.x; puppetlabs/stdib: Require 9.x 

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppet-grafana",
-      "version_requirement": ">= 10.0.0 < 12.0.0"
+      "version_requirement": ">= 13.0.0 < 14.0.0"
     },
     {
       "name": "puppet-telegraf",

--- a/metadata.json
+++ b/metadata.json
@@ -30,7 +30,7 @@
     },
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 1.0.0 < 9.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppet-telegraf",
-      "version_requirement": ">= 4.3.1 < 5.0.0"
+      "version_requirement": ">= 5.0.0 < 6.0.0"
     },
     {
       "name": "puppetlabs-apt",


### PR DESCRIPTION
Starting with puppet/telegraf 5 the toml-rb gem isn't required anymore. This requires puppetlabs/stdib 9.