### PR TITLE
Bump module dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "dependencies": [
     {
       "name": "puppet-grafana",
-      "version_requirement": ">= 10.0.0 < 12.0.0"
+      "version_requirement": ">= 13.0.0 < 14.0.0"
     },
     {
       "name": "puppet-telegraf",
-      "version_requirement": ">= 4.3.1 < 5.0.0"
+      "version_requirement": ">= 5.0.0 < 6.0.0"
     },
     {
       "name": "puppetlabs-apt",
@@ -26,11 +26,11 @@
     },
     {
       "name": "puppetlabs-influxdb",
-      "version_requirement": ">= 1.6.0 < 3.0.0"
+      "version_requirement": ">= 2.0.0 < 3.0.0"
     },
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 1.0.0 < 9.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This commit bumps the required module dependencies, particularly requiring stdlib >9