### PR TITLE
(SUP-4436) Grafana Module Version Change

### DIFF
--- a/manifests/profile/dashboards.pp
+++ b/manifests/profile/dashboards.pp
@@ -96,16 +96,6 @@ class puppet_operational_dashboards::profile::dashboards (
       manage_package_repo => $manage_grafana_repo,
     }
 
-    if $facts['os']['family'] == 'Debian' {
-      # Workaround to override the key id for the Grafana apt source
-      Apt::Source <| title == 'grafana' |> {
-        key => {
-          'id'     => '0E22EB88E39E12277A7760AE9E439B102CF3C0C6',
-          'source' => 'https://apt.grafana.com/gpg.key',
-        },
-      }
-    }
-
     file { 'grafana-conf-d':
       ensure => directory,
       path   => '/etc/systemd/system/grafana-server.service.d',

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppet-grafana",
-      "version_requirement": ">= 13.0.0 < 14.0.0"
+      "version_requirement": ">= 13.0.1 < 14.0.0"
     },
     {
       "name": "puppet-telegraf",


### PR DESCRIPTION
Removed Debian block from Dashboards.pp and changed version of grafana within metadata.json file, upping it from `3.0.0 to 3.0.1`

