### PR TITLE
Fix collection of postgres metrics on FOSS Puppet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@
 /log/
 /pkg/
 /spec/fixtures/manifests/
-/spec/fixtures/modules/
+/spec/fixtures/modules/*
 /tmp/
 /vendor/
 /convert_report.txt

--- a/.pdkignore
+++ b/.pdkignore
@@ -16,7 +16,7 @@
 /log/
 /pkg/
 /spec/fixtures/manifests/
-/spec/fixtures/modules/
+/spec/fixtures/modules/*
 /tmp/
 /vendor/
 /convert_report.txt
@@ -29,6 +29,7 @@
 /.fixtures.yml
 /Gemfile
 /.gitattributes
+/.github/
 /.gitignore
 /.pdkignore
 /.puppet-lint.rc

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ require:
 - rubocop-performance
 - rubocop-rspec
 AllCops:
+  NewCops: enable
   DisplayCopNames: true
   TargetRubyVersion: '2.6'
   Include:
@@ -529,6 +530,8 @@ Lint/DuplicateBranch:
   Enabled: false
 Lint/DuplicateMagicComment:
   Enabled: false
+Lint/DuplicateMatchPattern:
+  Enabled: false
 Lint/DuplicateRegexpCharacterClassElement:
   Enabled: false
 Lint/EmptyBlock:
@@ -645,6 +648,8 @@ Style/ComparableClamp:
   Enabled: false
 Style/ConcatArrayLiterals:
   Enabled: false
+Style/DataInheritance:
+  Enabled: false
 Style/DirEmpty:
   Enabled: false
 Style/DocumentDynamicEvalDefinition:
@@ -712,6 +717,8 @@ Style/RedundantEach:
 Style/RedundantHeredocDelimiterQuotes:
   Enabled: false
 Style/RedundantInitialize:
+  Enabled: false
+Style/RedundantLineContinuation:
   Enabled: false
 Style/RedundantSelfAssignmentBranch:
   Enabled: false

--- a/.sync.yml
+++ b/.sync.yml
@@ -43,6 +43,10 @@ spec/default_facts.yml:
       user: 'root'
     settings:
       module_groups: 'base+pe_only'
+    pe_postgresql_info:
+      installed_server_version: '14'
+    networking:
+      fqdn: 'foo.bar.com'
 .rubocop.yml:
   default_configs:
     "Layout/MultilineOperationIndentation":

--- a/Gemfile
+++ b/Gemfile
@@ -19,20 +19,21 @@ group :development do
   gem "json", '= 2.5.1',                         require: false if Gem::Requirement.create(['>= 3.0.0', '< 3.0.5']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.6.1',                         require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.6.3',                         require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "racc", '~> 1.4.0',                        require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "voxpupuli-puppet-lint-plugins", '~> 5.0', require: false
   gem "facterdb", '~> 1.18',                     require: false
   gem "metadata-json-lint", '~> 3.0',            require: false
   gem "puppetlabs_spec_helper", '~> 6.0',        require: false
   gem "rspec-puppet-facts", '~> 2.0',            require: false
-  gem "codecov", '~> 0.2',                       require: false
   gem "dependency_checker", '~> 1.0.0',          require: false
   gem "parallel_tests", '= 3.12.1',              require: false
   gem "pry", '~> 0.10',                          require: false
-  gem "simplecov-console", '~> 0.5',             require: false
+  gem "simplecov-console", '~> 0.9',             require: false
   gem "puppet-debugger", '~> 1.0',               require: false
-  gem "rubocop", '= 1.48.1',                     require: false
+  gem "rubocop", '~> 1.50.0',                    require: false
   gem "rubocop-performance", '= 1.16.0',         require: false
   gem "rubocop-rspec", '= 2.19.0',               require: false
+  gem "puppet-strings", '~> 4.0',                require: false
   gem "rb-readline", '= 0.5.5',                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "github_changelog_generator", '= 1.16.4',  require: false
   gem "concurrent-ruby", '= 1.1.10',             require: false
@@ -42,6 +43,10 @@ end
 group :system_tests do
   gem "puppet_litmus", '~> 1.0', require: false, platforms: [:ruby, :x64_mingw]
   gem "serverspec", '~> 2.41',   require: false
+end
+group :release_prep do
+  gem "puppet-strings", '~> 4.0',         require: false
+  gem "puppetlabs_spec_helper", '~> 6.0', require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/README.md
+++ b/README.md
@@ -154,9 +154,11 @@ Please note database access will not be granted until the Puppet agent run on th
 
 The toml-rb gem needs to be installed in the Puppetserver gem space, which can be done with the [influxdb::profile::toml](https://github.com/puppetlabs/influxdb/blob/main/manifests/profile/toml.pp) class in the InfluxDB module.
 
-To collect PostgreSQL metrics, FOSS users will need to manually configure the PostgreSQL authentication settings.
+To collect PostgreSQL metrics, FOSS users can apply the `puppet_operational_dashboards::profile::foss_postgres_access` class to any postgres nodes to configure authentication and grants for a `telegraf` user to connect.  This class has a dependency on the `puppetlabs/puppetdb` and `puppetlabs/postgresql` modules, and you must use the `puppetlabs/puppetdb` module to configure SSL for postgres.  See the documentation [here](https://forge.puppet.com/modules/puppetlabs/puppetdb/readme#enable-ssl-connections).
 
-The easiest way to get started using this module is by including the `puppet_operational_dashboards` class to install and configure Telegraf, InfluxDB, and Grafana.  Note that you also need to install the toml-rb gem according to the.
+You may also configure the connection options used by the Telegraf client when querying postgres.  These options can be set using the `puppet_operational_dashboards::telegraf::agent::postgres_options` class parameter.
+
+The easiest way to get started using this module is by including the `puppet_operational_dashboards` class to install and configure Telegraf, InfluxDB, and Grafana.  Note that you also need to install the toml-rb gem according to the documentation.
 
 ```
 include puppet_operational_dashboards

--- a/Rakefile
+++ b/Rakefile
@@ -1,89 +1,10 @@
 # frozen_string_literal: true
 
 require 'bundler'
-require 'puppet_litmus/rake_tasks' if Bundler.rubygems.find_name('puppet_litmus').any?
+require 'puppet_litmus/rake_tasks' if Gem.loaded_specs.key? 'puppet_litmus'
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-syntax/tasks/puppet-syntax'
-require 'github_changelog_generator/task' if Bundler.rubygems.find_name('github_changelog_generator').any?
-require 'puppet-strings/tasks' if Bundler.rubygems.find_name('puppet-strings').any?
-
-def changelog_user
-  return unless Rake.application.top_level_tasks.include? "changelog"
-  returnVal = "puppetlabs" || JSON.load(File.read('metadata.json'))['author']
-  raise "unable to find the changelog_user in .sync.yml, or the author in metadata.json" if returnVal.nil?
-  puts "GitHubChangelogGenerator user:#{returnVal}"
-  returnVal
-end
-
-def changelog_project
-  return unless Rake.application.top_level_tasks.include? "changelog"
-
-  returnVal = nil
-  returnVal ||= begin
-    metadata_source = JSON.load(File.read('metadata.json'))['source']
-    metadata_source_match = metadata_source && metadata_source.match(%r{.*\/([^\/]*?)(?:\.git)?\Z})
-
-    metadata_source_match && metadata_source_match[1]
-  end
-
-  raise "unable to find the changelog_project in .sync.yml or calculate it from the source in metadata.json" if returnVal.nil?
-
-  puts "GitHubChangelogGenerator project:#{returnVal}"
-  returnVal
-end
-
-def changelog_future_release
-  return unless Rake.application.top_level_tasks.include? "changelog"
-  returnVal = "v%s" % JSON.load(File.read('metadata.json'))['version']
-  raise "unable to find the future_release (version) in metadata.json" if returnVal.nil?
-  puts "GitHubChangelogGenerator future_release:#{returnVal}"
-  returnVal
-end
+require 'puppet-strings/tasks' if Gem.loaded_specs.key? 'puppet-strings'
 
 PuppetLint.configuration.send('disable_relative')
 PuppetLint.configuration.send('disable_lookup_in_parameter')
-
-
-if Bundler.rubygems.find_name('github_changelog_generator').any?
-  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-    raise "Set CHANGELOG_GITHUB_TOKEN environment variable eg 'export CHANGELOG_GITHUB_TOKEN=valid_token_here'" if Rake.application.top_level_tasks.include? "changelog" and ENV['CHANGELOG_GITHUB_TOKEN'].nil?
-    config.user = "#{changelog_user}"
-    config.project = "#{changelog_project}"
-    config.future_release = "#{changelog_future_release}"
-    config.exclude_labels = ['maintenance']
-    config.header = "# Change log\n\nAll notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org)."
-    config.add_pr_wo_labels = true
-    config.issues = false
-    config.merge_prefix = "### UNCATEGORIZED PRS; LABEL THEM ON GITHUB"
-    config.configure_sections = {
-      "Changed" => {
-        "prefix" => "### Changed",
-        "labels" => ["backwards-incompatible"],
-      },
-      "Added" => {
-        "prefix" => "### Added",
-        "labels" => ["enhancement", "feature"],
-      },
-      "Fixed" => {
-        "prefix" => "### Fixed",
-        "labels" => ["bug", "documentation", "bugfix"],
-      },
-    }
-  end
-else
-  desc 'Generate a Changelog from GitHub'
-  task :changelog do
-    raise <<EOM
-The changelog tasks depends on recent features of the github_changelog_generator gem.
-Please manually add it to your .sync.yml for now, and run `pdk update`:
----
-Gemfile:
-  optional:
-    ':development':
-      - gem: 'github_changelog_generator'
-        version: '~> 1.15'
-        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')"
-EOM
-  end
-end
-

--- a/manifests/profile/foss_postgres_access.pp
+++ b/manifests/profile/foss_postgres_access.pp
@@ -1,0 +1,56 @@
+# @summary Allows Telegraf to connect and collect metrics from postgres nodes
+# @example Basic usage
+#   include puppet_operational_dashboards::profile::foss_postgres_access
+# @param telegraf_hosts
+#   A list of FQDNs running Telegraf to allow access to
+# @param telegraf_user
+#   Username for the Telegraf client to use in the postgres connection string
+class puppet_operational_dashboards::profile::foss_postgres_access (
+  Array $telegraf_hosts = puppet_operational_dashboards::hosts_with_profile('Puppet_operational_dashboards::Telegraf::Agent'),
+  String $telegraf_user = 'telegraf',
+) {
+  postgresql::server::role { $telegraf_user:
+    ensure => present,
+    db     => 'puppetdb',
+  }
+
+  postgresql::server::database_grant { "puppetdb grant connect to ${telegraf_user}":
+    privilege => 'CONNECT',
+    db        => 'puppetdb',
+    role      => $telegraf_user,
+    require   => Postgresql::Server::Role[$telegraf_user],
+  }
+
+  postgresql::server::grant_role { 'monitoring':
+    group   => 'pg_monitor',
+    role    => $telegraf_user,
+    require => Postgresql::Server::Role[$telegraf_user],
+  }
+
+  postgresql::server::pg_hba_rule { "Allow certificate mapped connections to puppetdb as ${telegraf_user} (ipv4)":
+    type        => 'hostssl',
+    database    => 'puppetdb',
+    user        => $telegraf_user,
+    address     => '0.0.0.0/0',
+    auth_method => 'cert',
+    order       => 0,
+    auth_option => 'map=puppetdb-telegraf-map clientcert=1',
+  }
+
+  postgresql::server::pg_hba_rule { "Allow certificate mapped connections to puppetdb as ${telegraf_user} (ipv6)":
+    type        => 'hostssl',
+    database    => 'puppetdb',
+    user        => $telegraf_user,
+    address     => '::0/0',
+    auth_method => 'cert',
+    order       => 0,
+    auth_option => 'map=puppetdb-telegraf-map clientcert=1',
+  }
+  $telegraf_hosts.each |$host| {
+    postgresql::server::pg_ident_rule { "Map the SSL certificate of ${host} as a puppetdb user":
+      map_name          => 'puppetdb-telegraf-map',
+      system_username   => $host,
+      database_username => $telegraf_user,
+    }
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -92,7 +92,7 @@
       "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ],
-  "pdk-version": "2.7.1",
+  "pdk-version": "3.0.1",
   "template-url": "https://github.com/puppetlabs/pdk-templates#main",
-  "template-ref": "heads/main-0-gab2bd48"
+  "template-ref": "heads/main-0-g1ac3168"
 }

--- a/spec/classes/foss_postgres_spec.rb
+++ b/spec/classes/foss_postgres_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'puppet_operational_dashboards::profile::foss_postgres_access' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:pre_condition) do
+        <<-PRE_COND
+          include puppetdb
+          include puppetdb::master::config
+        PRE_COND
+      end
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+
+      describe 'when using default parameters' do
+        let(:pre_condition) do
+          <<-PRE_COND
+                include puppetdb
+                include puppetdb::master::config
+          PRE_COND
+        end
+        let(:params) do
+          { telegraf_hosts: ['foo.bar.com'] }
+        end
+
+        it {
+          is_expected.to contain_postgresql__server__role('telegraf').with(
+            ensure: 'present',
+            db: 'puppetdb',
+          )
+
+          is_expected.to contain_postgresql__server__database_grant('puppetdb grant connect to telegraf').with(
+            privilege: 'CONNECT',
+            db: 'puppetdb',
+            role: 'telegraf',
+          )
+          is_expected.to contain_postgresql__server__database_grant('puppetdb grant connect to telegraf').that_requires('Postgresql::Server::Role[telegraf]')
+
+          is_expected.to contain_postgresql__server__grant_role('monitoring').with(
+            group: 'pg_monitor',
+            role: 'telegraf',
+          )
+          is_expected.to contain_postgresql__server__grant_role('monitoring').that_requires('Postgresql::Server::Role[telegraf]')
+
+          is_expected.to contain_postgresql__server__pg_hba_rule('Allow certificate mapped connections to puppetdb as telegraf (ipv4)').with(
+            type: 'hostssl',
+            database: 'puppetdb',
+            user: 'telegraf',
+            address: '0.0.0.0/0',
+            auth_method: 'cert',
+            order: 0,
+            auth_option: 'map=puppetdb-telegraf-map clientcert=1',
+          )
+
+          is_expected.to contain_postgresql__server__pg_hba_rule('Allow certificate mapped connections to puppetdb as telegraf (ipv6)').with(
+            type: 'hostssl',
+            database: 'puppetdb',
+            user: 'telegraf',
+            address: '::0/0',
+            auth_method: 'cert',
+            order: 0,
+            auth_option: 'map=puppetdb-telegraf-map clientcert=1',
+          )
+
+          is_expected.to contain_postgresql__server__pg_ident_rule('Map the SSL certificate of foo.bar.com as a puppetdb user').with(
+            map_name: 'puppetdb-telegraf-map',
+            system_username: 'foo.bar.com',
+            database_username: 'telegraf',
+          )
+        }
+      end
+    end
+  end
+end

--- a/spec/classes/postgres_access_spec.rb
+++ b/spec/classes/postgres_access_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'puppet_operational_dashboards::profile::postgres_access' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let(:pre_condition) do
+        <<-PRE_COND
+        class pe_postgresql::server {}
+        include pe_postgresql::server
+        define pe_postgresql_psql(
+          $db,
+          $port,
+          $psql_user,
+          $psql_group,
+          $unless,
+          $psql_path,
+          $command = 'foo',
+        ) {}
+        define pe_postgresql::server::database_grant(
+          $privilege,
+          $db,
+          $role
+        ) {}
+        define puppet_enterprise::pg::cert_allowlist_entry(
+          $user,
+          $database,
+          $allowed_client_certname,
+          $pg_ident_conf_path,
+          $ip_mask_allow_all_users_ssl,
+          $ipv6_mask_allow_all_users_ssl,
+        ) {}
+        PRE_COND
+      end
+
+      it { is_expected.to compile }
+    end
+  end
+
+  context 'on puppet enterprise' do
+    let(:pre_condition) do
+      <<-PRE_COND
+      class pe_postgresql::server {}
+      include pe_postgresql::server
+      define pe_postgresql_psql(
+        $db,
+        $port,
+        $psql_user,
+        $psql_group,
+        $unless,
+        $psql_path,
+        $command = 'foo',
+      ) {}
+      define pe_postgresql::server::database_grant(
+        $privilege,
+        $db,
+        $role
+      ) {}
+        define puppet_enterprise::pg::cert_allowlist_entry(
+          $user,
+          $database,
+          $allowed_client_certname,
+          $pg_ident_conf_path,
+          $ip_mask_allow_all_users_ssl,
+          $ipv6_mask_allow_all_users_ssl,
+        ) {}
+      PRE_COND
+    end
+
+    context 'when using default parameters' do
+      let(:params) do
+        { telegraf_hosts: ['foo.bar.com'] }
+      end
+
+      it {
+        is_expected.to contain_pe_postgresql_psql('CREATE ROLE telegraf LOGIN').with(
+          db: 'pe-puppetdb',
+          port: '5432',
+          psql_user: 'pe-postgres',
+          psql_group: 'pe-postgres',
+          unless: "SELECT rolname FROM pg_roles WHERE rolname='telegraf'",
+          psql_path: '/opt/puppetlabs/server/bin/psql',
+        )
+        is_expected.to contain_pe_postgresql_psql('CREATE ROLE telegraf LOGIN').that_requires('Class[pe_postgresql::server]')
+
+        is_expected.to contain_pe_postgresql__server__database_grant('operational_dashboards_telegraf').with(
+          privilege: 'CONNECT',
+          db: 'pe-puppetdb',
+          role: 'telegraf',
+        )
+        is_expected.to contain_pe_postgresql__server__database_grant('operational_dashboards_telegraf').that_requires('Pe_postgresql_psql[CREATE ROLE telegraf LOGIN]')
+
+        is_expected.to contain_pe_postgresql_psql('telegraf_pg_monitor_grant').with(
+          db: 'pe-puppetdb',
+          port: '5432',
+          psql_user: 'pe-postgres',
+          psql_group: 'pe-postgres',
+          command: 'GRANT pg_monitor TO telegraf',
+          unless: "select 1 from pg_roles where pg_has_role( 'telegraf', 'pg_monitor', 'member')",
+          psql_path: '/opt/puppetlabs/server/bin/psql',
+        )
+        is_expected.to contain_pe_postgresql_psql('telegraf_pg_monitor_grant').that_requires('Pe_postgresql_psql[CREATE ROLE telegraf LOGIN]')
+
+        is_expected.to contain_puppet_enterprise__pg__cert_allowlist_entry('telegraf_foo.bar.com').with(
+          user: 'telegraf',
+          database: 'pe-puppetdb',
+          allowed_client_certname: 'foo.bar.com',
+          pg_ident_conf_path: '/opt/puppetlabs/server/data/postgresql/14/data/pg_ident.conf',
+          ip_mask_allow_all_users_ssl: '0.0.0.0/0',
+          ipv6_mask_allow_all_users_ssl: '::/0',
+        )
+      }
+    end
+  end
+end

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -2,13 +2,17 @@
 #
 # Facts specified here will override the values provided by rspec-puppet-facts.
 ---
-ipaddress: "172.16.254.254"
-ipaddress6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
+networking:
+  ip: "172.16.254.254"
+  ip6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
+  mac: "AA:AA:AA:AA:AA:AA"
+  fqdn: "foo.bar.com"
 is_pe: false
-macaddress: "AA:AA:AA:AA:AA:AA"
 pe_build: 2021.5.0
 identity:
   user: root
 settings:
   module_groups: base+pe_only
+pe_postgresql_info:
+  installed_server_version: '14'
 

--- a/templates/postgres.epp
+++ b/templates/postgres.epp
@@ -1,5 +1,17 @@
-<%- | String $certname | -%>
-address = "postgres://telegraf@<%=$certname%>:5432/pe-puppetdb?sslmode=verify-full&sslkey=/etc/telegraf/puppet_key.pem&sslcert=/etc/telegraf/puppet_cert.pem&sslrootcert=/etc/telegraf/puppet_ca.pem"
+<%- |
+  String $certname,
+  String $telegraf_user,
+  Optional[Sensitive] $password,
+  String $database,
+  Integer $port,
+  String $connection_params,
+| -%>
+<% if $password { -%>
+address = "postgres://<%=$telegraf_user%>:<%=$password.unwrap%>@<%=$certname%>:<%=$port%>/<%=$database%>?<%=$connection_params%>"
+<% } -%>
+<% else { -%>
+address = "postgres://<%=$telegraf_user%>@<%=$certname%>:<%=$port%>/<%=$database%>?<%=$connection_params%>"
+<% } -%>
 databases = ["pe-puppetdb"]
 outputaddress = "<%=$certname%>"
 [[query]]


### PR DESCRIPTION
This commit fixes postgres metrics on FOSS by:
    
* Choosing the appropriate database, 'puppet' or 'pe-puppet'
* Adding a new profile class to set up postgres auth
* Making the postgres connection string more configurable
