### PR TITLE
Decreased minimum stdlib version to 8

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-puppet_operational_dashboards",
-  "version": "2.3.1",
+  "version": "2.3.0",
   "author": "Adrian Parreiras Horta",
   "summary": "A module for managing the installation and configuration of metrics dashboards for Puppet Infrastructure.",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-puppet_operational_dashboards",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": "Adrian Parreiras Horta",
   "summary": "A module for managing the installation and configuration of metrics dashboards for Puppet Infrastructure.",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -30,7 +30,7 @@
     },
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 9.0.0 < 10.0.0"
+      "version_requirement": ">= 8.0.0 < 10.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Due to the error in version 2.0.0 relating to installing external packages due to an expired GPG key, customers are stuck when installing the operation dashboard if they are currently not on stdlib >= 9.   Customers with large modules estates have difficulties moving all modules beyond version stdlib 9 due to existing compatibility issues.