### PR TITLE
Change to datasource to allow editable so buckets can be deleted

### DIFF
--- a/files/datasource.epp
+++ b/files/datasource.epp
@@ -23,3 +23,4 @@ datasources:
   secureJsonData:
     httpHeaderValue1: 'Token <%= $token %>'
   readOnly: false
+  editable: true


### PR DESCRIPTION
Currently empty buckets are being kept on the system. These can be removed via swagger API or UI if the editable: true property is added to this epp file