### PR TITLE
(SUP-6706): Update Grafana to 11.8.6

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -401,7 +401,7 @@ Data type: `String`
 
 Version of the Grafana package to install.
 
-Default value: `'8.5.27'`
+Default value: `'11.6.8'`
 
 ##### <a name="-puppet_operational_dashboards--profile--dashboards--grafana_datasource"></a>`grafana_datasource`
 

--- a/manifests/profile/dashboards.pp
+++ b/manifests/profile/dashboards.pp
@@ -76,7 +76,7 @@ class puppet_operational_dashboards::profile::dashboards (
   Integer $grafana_timeout = 10,
   #TODO: document using task to change
   Sensitive[String] $grafana_password = Sensitive('admin'),
-  String $grafana_version = '8.5.27',
+  String $grafana_version = '11.6.8',
   String $grafana_datasource = 'influxdb_puppet',
   String $grafana_install = $facts['os']['family'] ? {
     /(RedHat|Debian)/ => 'repo',

--- a/spec/classes/dashboards_spec.rb
+++ b/spec/classes/dashboards_spec.rb
@@ -31,7 +31,7 @@ describe 'puppet_operational_dashboards::profile::dashboards' do
   context 'when using default parameters' do
     it {
       is_expected.to contain_class('grafana').with(
-        version: '8.5.27',
+        version: '11.6.8',
         manage_package_repo: true,
       )
 


### PR DESCRIPTION
Updated to the lowest supported major version for compatibility reasons